### PR TITLE
fix: macos build

### DIFF
--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
 		85ED2F22B0DC212004342B6F /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92AC0AB39EC7D98182F4FA38 /* Pods_Runner.framework */; };
+		F94E0AC72CB41AB900F42987 /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F94E0AC62CB41AB900F42987 /* MediaPlayer.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		AB17CEC867529B435E38FDD3 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		B0431E7E8F1EA155EC447E6C /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		F94E0AC62CB41AB900F42987 /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +105,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F94E0AC72CB41AB900F42987 /* MediaPlayer.framework in Frameworks */,
 				85ED2F22B0DC212004342B6F /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -195,13 +198,13 @@
 				B0431E7E8F1EA155EC447E6C /* Pods-RunnerTests.release.xcconfig */,
 				04711A5356DB78E344D52D56 /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F94E0AC62CB41AB900F42987 /* MediaPlayer.framework */,
 				92AC0AB39EC7D98182F4FA38 /* Pods_Runner.framework */,
 				923B35C26D5F4B6D1FD83CB9 /* Pods_RunnerTests.framework */,
 			);


### PR DESCRIPTION
Add `MediaPlayer.framework` to fix 

`symbol not found in flat namespace '_MPMediaItemPropertyAlbumTitle'`

 issue.