### PR TITLE
fix: do not replace artifacts while uploading release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           artifacts: build/windows/x64/runner/Release/Rune-*.zip
           allowUpdates: true
+          replacesArtifacts: false
 
   build-linux:
     permissions:
@@ -152,6 +153,7 @@ jobs:
         with:
           artifacts: build/linux/x64/release/bundle/Rune-*.zip
           allowUpdates: true
+          replacesArtifacts: false
     
       
       


### PR DESCRIPTION
Maybe fix the problem of only having one single build in the release.