### PR TITLE
fix Android compile process

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace = "com.example.player"
+    namespace = "ci.not.rune"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.player"
+        applicationId = "ci.not.rune"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk = flutter.minSdkVersion

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -51,6 +51,69 @@ android {
             signingConfig = signingConfigs.debug
         }
     }
+
+    // below are the configurations for Rust and libc++_shared.so
+    // in short, we copy the libc++_shared.so from NDK to JniLibs and clean it after assembling
+    afterEvaluate {
+        def ndkDir = android.ndkDirectory
+        def libCppDir = "$ndkDir/sources/cxx-stl/llvm-libc++/libs"
+        def jniLibsDir = "$projectDir/src/main/jniLibs"
+        def abis = ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
+
+        // clean JniLibs before and after merge, ensuring that the libc++_shared.so is always up-to-date.
+        task cleanJniLibs {
+            doLast {
+                abis.each { abi ->
+                    def libcSoDest = file("$jniLibsDir/$abi/libc++_shared.so")
+                    if (libcSoDest.exists()) {
+                        println "Deleting $libcSoDest"
+                        libcSoDest.delete() // 构建前清理文件
+                    }
+                }
+            }
+        }
+
+        // copy libc++_shared.so to JniLibs
+        task copyLibcxxShared {
+            doLast {
+                println "Now let's make libhub.so happy ;)"
+                abis.each { abi ->
+                    def libcSoSrc = file("$libCppDir/$abi/libc++_shared.so")
+                    def libcSoDest = file("$jniLibsDir/$abi/libc++_shared.so")
+                    if (libcSoSrc.exists()) {
+                        println "Copying $libcSoSrc to $libcSoDest"
+                        copy {
+                            from libcSoSrc
+                            into "$jniLibsDir/$abi"
+                        }
+                    } else {
+                        throw new Exception("libc++_shared.so for ABI $abi not found in NDK at $libCppDir.")
+                    }
+                }
+            }
+        }
+
+        // when merging JniLibs, first clean then copy
+        tasks.matching { 
+            it.name.startsWith('merge') && it.name.contains('JniLib')
+        }.all { task ->
+            task.dependsOn cleanJniLibs
+            task.dependsOn copyLibcxxShared
+        }
+
+        // after assembling, clean JniLibs
+        tasks.matching { 
+            it.name.startsWith('assemble') || it.name.contains('build')
+        }.all { task ->
+            // avoid using task.finalizedBy(cleanJniLibs) because it will cause circular dependency
+            task.doLast {
+                println "Cleaning JniLibs after $task.name"
+                cleanJniLibs.actions.each {
+                    it.execute(task)
+                }
+            }
+        }
+    }
 }
 
 flutter {

--- a/android/app/src/main/kotlin/ci/not/rune/MainActivity.kt
+++ b/android/app/src/main/kotlin/ci/not/rune/MainActivity.kt
@@ -1,0 +1,7 @@
+package ci.not.rune
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity: FlutterActivity() {
+    
+}

--- a/android/app/src/main/kotlin/com/example/player/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/player/MainActivity.kt
@@ -1,5 +1,0 @@
-package com.example.player
-
-import io.flutter.embedding.android.FlutterActivity
-
-class MainActivity: FlutterActivity()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,10 +6,31 @@ allprojects {
 }
 
 rootProject.buildDir = "../build"
+
 subprojects {
+    // unify compileSdk to 31 to work around https://github.com/flutter/flutter/issues/153281
+    afterEvaluate { project ->
+        if (project.extensions.findByName("android") != null) {
+            Integer pluginCompileSdk = project.android.compileSdk
+            if (pluginCompileSdk != null && pluginCompileSdk < 31) {
+                project.logger.error(
+                        "Warning: Overriding compileSdk version in Flutter plugin: "
+                                + project.name
+                                + " from "
+                                + pluginCompileSdk
+                                + " to 31 (to work around https://issuetracker.google.com/issues/199180389)."
+                                + "\nIf there is not a new version of " + project.name + ", consider filing an issue against "
+                                + project.name
+                                + " to increase their compileSdk to the latest (otherwise try updating to the latest version)."
+                )
+                project.android {
+                    compileSdk 31
+                }
+            }
+        }
+    }
+    
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(":app")
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,9 @@ import 'router.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await windowManager.ensureInitialized();
+  if (!Platform.isAndroid) {
+    await windowManager.ensureInitialized();
+  }
   await FullScreen.ensureInitialized();
   await GetStorage.init();
   await GetStorage.init(MacSecureManager.storageName);

--- a/native/hub/build.rs
+++ b/native/hub/build.rs
@@ -1,7 +1,17 @@
+use std::env;
 use anyhow::Result;
 use vergen_git2::{BuildBuilder, Emitter, Git2Builder, RustcBuilder};
 
 fn main() -> Result<()> {
+    let target_os = env::var("CARGO_CFG_TARGET_OS");
+    match target_os.as_ref().map(|x| &**x) {
+        Ok("android") => {
+            println!("cargo:rustc-link-lib=dylib=stdc++");
+            println!("cargo:rustc-link-lib=c++_shared");
+        },
+        _ => {}
+    }
+
     let git2 = Git2Builder::all_git()?;
     let build = BuildBuilder::all_build()?;
     let rustc = RustcBuilder::all_rustc()?;

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -16,8 +16,10 @@ rodio = { version = "0.19.0", features = [] }
 rustfft = "6.2.0"
 tokio-util = "0.7.11"
 rand = "0.8.5"
-souvlaki = "0.7.3"
 anyhow = "1.0.89"
 raw-window-handle = "0.5.2"
 windows = {version = "0.44.0", features = ["Win32_System_LibraryLoader", "Win32_UI", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_Graphics_Gdi"] }
 once_cell = "1.20.2"
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+souvlaki = "0.7.3"

--- a/playback/src/dummy_souvlaki.rs
+++ b/playback/src/dummy_souvlaki.rs
@@ -1,0 +1,84 @@
+/// A dummy implementation of the media controls.
+
+use std::time::Duration;
+
+/// The metadata of a media item.
+#[derive(Clone, Debug, Default)]
+pub struct MediaMetadata<'a> {
+    pub title: Option<&'a str>,
+    pub album: Option<&'a str>,
+    pub artist: Option<&'a str>,
+    pub cover_url: Option<&'a str>,
+    pub duration: Option<Duration>,
+}
+
+/// The status of media playback.
+#[derive(Clone, Debug)]
+pub enum MediaPlayback {
+    Stopped,
+    Paused { progress: Option<MediaPosition> },
+    Playing { progress: Option<MediaPosition> },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MediaPosition(pub Duration);
+
+#[derive(Clone, Debug)]
+pub enum MediaControlEvent {
+    Play,
+    Pause,
+    Toggle,
+    Next,
+    Previous,
+    Stop,
+    Seek(SeekDirection),
+    SetPosition(MediaPosition),
+}
+
+#[derive(Clone, Debug)]
+pub enum SeekDirection {
+    Forward,
+    Backward,
+}
+
+pub struct PlatformConfig {
+    pub dbus_name: &'static str,
+    pub display_name: &'static str,
+}
+
+/// A platform-specific error.
+#[derive(Debug)]
+pub struct Error;
+
+/// A handle to OS media controls.
+pub struct MediaControls;
+
+impl MediaControls {
+    /// Create media controls with the specified config.
+    pub fn new(_config: PlatformConfig) -> Result<Self, Error> {
+        Ok(Self)
+    }
+
+    /// Attach the media control events to a handler.
+    pub fn attach<F>(&mut self, _event_handler: F) -> Result<(), Error>
+    where
+        F: Fn(MediaControlEvent) + Send + 'static,
+    {
+        Ok(())
+    }
+
+    /// Detach the event handler.
+    pub fn detach(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    /// Set the current playback status.
+    pub fn set_playback(&mut self, _playback: MediaPlayback) -> Result<(), Error> {
+        Ok(())
+    }
+
+    /// Set the metadata of the currently playing media item.
+    pub fn set_metadata(&mut self, _metadata: MediaMetadata) -> Result<(), Error> {
+        Ok(())
+    }
+}

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -1,9 +1,15 @@
 mod internal;
 mod realtime_fft;
+#[cfg(target_os = "android")]
+mod dummy_souvlaki;
 
 pub mod controller;
 pub mod player;
 
+#[cfg(not(target_os = "android"))]
 pub use souvlaki::{MediaMetadata, MediaPlayback, MediaPosition};
+
+#[cfg(target_os = "android")]
+pub use dummy_souvlaki::{MediaMetadata, MediaPlayback, MediaPosition};
 
 pub use internal::{PlayerCommand, PlayerEvent};


### PR DESCRIPTION
To be concise, after applying this patch, on a machine already set up Android SDK, executing `flutter build apk` should give you the apk file correctly.

***

In detail, this patch does these things:

1. Replace `souvlaki` with a dummy implementation when targeting Android. This is because media control on Android should be done through Android code, while when building current `souvlaki` code targeting Android, the macro cfg conflicts and build fails.
2. Force libraries with SDK version lower than 31 to use 31, fixing https://issuetracker.google.com/issues/199180389
3. When platform is Android, in `lib/main.dart` don't wait for `windowManager.ensureInitialized();` since [window_manager](https://pub.dev/packages/window_manager) does not support Android.

With above changes, the build could pass, but when `libhub.so` loads, it will look for `libc++_shared.so` , find nothing, and then stop working. Hence the commit [#aa78bf1](https://github.com/Losses/rune/commit/aa78bf17b3e73284a97165cdbf79c65c30dcc11b) to manually copy `libc++_shared.so` from NDK to `android/app/src/main/jniLibs` so that it will be packaged into the final apk.

There are an open issue on RustAudio: https://github.com/RustAudio/rodio/issues/404 , some "successful attempts" on rinf: https://github.com/cunarist/rinf/issues/280 , and [this section of rinf FAQ](https://rinf.cunarist.com/frequently-asked-questions/#my-app-failed-to-load-dynamic-library) . But for rune, only such modification to `build.rs` is still not packaging `libc++_shared.so` , only fixing some STL identifiers not found. Adding arguments to `android{ defaultConfig{ externalNativeBuild { ndkBuild {` won't work, too.

I'm pretty confused. But let's just manually copy them at least for now.