### PR TITLE
fix: Play Next option in Add to Queue setting not work

### DIFF
--- a/lib/utils/get_non_replace_operate_mode.dart
+++ b/lib/utils/get_non_replace_operate_mode.dart
@@ -10,7 +10,7 @@ Future<PlaylistOperateMode> getNonReplaceOperateMode() async {
   String? storedVolume =
       await settingsManager.getValue<String>(nonReplaceOperateModeKey);
 
-  return storedVolume == 'play_next'
+  return storedVolume == 'PlayNext'
       ? PlaylistOperateMode.PlayNext
       : PlaylistOperateMode.AppendToEnd;
 }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the 'Play Next' option in the 'Add to Queue' setting by correcting the stored value comparison.