### PR TITLE
pref: optimize CPU mode analyze by switching from rustfft to realfft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "num-complex",
  "pollster",
  "rand",
+ "realfft",
  "rubato",
  "rustfft",
  "symphonia",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytemuck",
+ "criterion",
  "futures",
  "lazy_static",
  "log",
@@ -140,6 +141,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -766,6 +773,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +845,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1082,6 +1122,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2203,6 +2279,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -2929,6 +3014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "openssl"
 version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,6 +3304,34 @@ dependencies = [
  "tokio",
  "tokio-util",
  "windows 0.44.0",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -5066,6 +5185,16 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -24,3 +24,4 @@ tokio-util = "0.7.11"
 rand = "0.8.5"
 tokio = { version = "1.0.0", features = ["rt", "rt-multi-thread", "macros"] }
 tracing-subscriber = "0.3.18"
+realfft = "3.4.0"

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -8,6 +8,13 @@ publish = false
 name = "analysis"
 path = "src/lib.rs"
 
+[dev-dependencies]
+criterion = { version = "0.5.1", features = ["html_reports"] }
+
+[[bench]]
+name = "analysis_benchmark"
+harness = false
+
 [dependencies]
 anyhow = {version="1.0.86",  features = ["backtrace"] }
 lazy_static = "1.5.0"

--- a/analysis/benches/analysis_benchmark.rs
+++ b/analysis/benches/analysis_benchmark.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 fn cpu_analysis_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("cpu analysis");
-    group.significance_level(0.1).sample_size(1000).measurement_time(Duration::from_secs(100));
+    group.significance_level(0.01).sample_size(100).measurement_time(Duration::from_secs(20));
     group.bench_function(
         "cpu analysis", |b| b.iter(
             || cpu_fft(black_box("../assets/startup_0.ogg"), 1024, 512, None)

--- a/analysis/benches/analysis_benchmark.rs
+++ b/analysis/benches/analysis_benchmark.rs
@@ -1,0 +1,17 @@
+use std::{hint::black_box, time::Duration};
+use analysis::fft_processor::cpu_fft;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn cpu_analysis_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cpu analysis");
+    group.significance_level(0.1).sample_size(1000).measurement_time(Duration::from_secs(100));
+    group.bench_function(
+        "cpu analysis", |b| b.iter(
+            || cpu_fft(black_box("../assets/startup_0.ogg"), 1024, 512, None)
+        )
+    );
+    group.finish();
+}
+
+criterion_group!(benches, cpu_analysis_benchmark);
+criterion_main!(benches);

--- a/analysis/src/fft_processor.rs
+++ b/analysis/src/fft_processor.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use log::{debug, info};
 
 use rubato::{FftFixedInOut, Resampler};
-use rustfft::Fft;
-use rustfft::{num_complex::Complex, FftPlanner};
+use rustfft::{num_complex::Complex};
 use symphonia::core::audio::{AudioBuffer, AudioBufferRef, Signal};
 use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
 use symphonia::core::conv::IntoSample;
@@ -89,12 +88,6 @@ impl FFTProcessor {
         let avg_spectrum = vec![Complex::new(0.0, 0.0); window_size];
         let hanning_window = build_hanning_window(window_size);
         let sample_buffer = Vec::with_capacity(window_size);
-        let mut planner = FftPlanner::<f32>::new();
-        let cpu_batch_fft = if computing_device == ComputingDevice::Cpu {
-            Some(planner.plan_fft_forward(window_size))
-        } else {
-            None
-        };
 
         let mut planner = RealFftPlanner::<f32>::new();
         let cpu_batch_fft = planner.plan_fft_forward(window_size);
@@ -428,7 +421,7 @@ impl FFTProcessor {
             ).expect("Real FFT processing failed");
 
             for batch_idx in 0..self.batch_cache_buffer_count {
-                let start = batch_idx * self.window_size;
+                let _start: usize = batch_idx * self.window_size;
                 for i in 0..self.window_size / 2 + 1 {
                     // Copy the real FFT output directly
                     self.avg_spectrum[i] += self.cpu_batch_fft_output_buffer[i];
@@ -449,7 +442,7 @@ impl FFTProcessor {
             ).expect("FFT processing failed");
 
             for batch_idx in 0..self.batch_size {
-                let start = batch_idx * self.window_size;
+                let _start = batch_idx * self.window_size;
 
                 for i in 0..self.window_size / 2 + 1 {
                     // Copy the real FFT output directly
@@ -510,7 +503,7 @@ mod tests {
     #[test]
     fn test_rust_fft() {
         let size = 1024;
-        let mut original_data: Vec<Complex<f32>> = (0..size)
+        let original_data: Vec<Complex<f32>> = (0..size)
             .map(|i| Complex::new((i as f32).sin(), 0.0))
             .collect();
         let mut fft_data = original_data.clone();

--- a/analysis/src/fft_processor.rs
+++ b/analysis/src/fft_processor.rs
@@ -422,10 +422,10 @@ impl FFTProcessor {
             .expect("CPU computing device not initialized");
 
         if force {
-            let _ = cpu_fft.process(
+            cpu_fft.process(
                 &mut self.cpu_batch_fft_buffer,
                 &mut self.cpu_batch_fft_output_buffer,
-            );
+            ).expect("Real FFT processing failed");
 
             for batch_idx in 0..self.batch_cache_buffer_count {
                 let start = batch_idx * self.window_size;
@@ -443,10 +443,10 @@ impl FFTProcessor {
 
             self.batch_cache_buffer_count = 0;
         } else if self.batch_cache_buffer_count >= self.batch_size {
-            let _ = cpu_fft.process(
+            cpu_fft.process(
                 &mut self.cpu_batch_fft_buffer,
                 &mut self.cpu_batch_fft_output_buffer,
-            );
+            ).expect("FFT processing failed");
 
             for batch_idx in 0..self.batch_size {
                 let start = batch_idx * self.window_size;

--- a/analysis/src/fft_processor.rs
+++ b/analysis/src/fft_processor.rs
@@ -19,6 +19,7 @@ use crate::features::zcr;
 
 use crate::fft_utils::*;
 use crate::wgpu_fft::wgpu_radix4;
+use realfft::{RealFftPlanner, RealToComplex};
 
 pub struct FFTProcessor {
     computing_device: ComputingDevice,
@@ -26,7 +27,9 @@ pub struct FFTProcessor {
     batch_size: usize,
     overlap_size: usize,
     gpu_batch_fft: Option<wgpu_radix4::FFTCompute>,
-    cpu_batch_fft: Option<Arc<dyn Fft<f32>>>,
+    cpu_batch_fft: Option<Arc<dyn RealToComplex<f32>>>,
+    cpu_batch_fft_output_buffer: Vec<Complex<f32>>,
+    cpu_batch_fft_buffer: Vec<f32>,
     batch_fft_buffer: Vec<Complex<f32>>,
     avg_spectrum: Vec<Complex<f32>>,
     hanning_window: Vec<f32>,
@@ -69,7 +72,7 @@ impl FFTProcessor {
     pub fn new(
         computing_device: ComputingDevice,
         window_size: usize,
-        // for cpu mode, batch_size is recommended to be 1
+        // for cpu mode, batch_size must to be 1
         // for gpu mode, batch_size is recommended to be 1024 * 8
         batch_size: usize,
         overlap_size: usize,
@@ -92,6 +95,12 @@ impl FFTProcessor {
         } else {
             None
         };
+
+        let mut planner = RealFftPlanner::<f32>::new();
+        let cpu_batch_fft = planner.plan_fft_forward(window_size);
+        let cpu_batch_fft_output_buffer = cpu_batch_fft.make_output_vec();
+        let cpu_batch_fft_buffer = cpu_batch_fft.make_input_vec();
+
         let fn_is_cancelled: Box<dyn Fn() -> bool> = Box::new(move || {
             cancel_token
                 .as_ref()
@@ -105,7 +114,9 @@ impl FFTProcessor {
             batch_size,
             overlap_size,
             gpu_batch_fft,
-            cpu_batch_fft,
+            cpu_batch_fft: Some(cpu_batch_fft),
+            cpu_batch_fft_output_buffer,
+            cpu_batch_fft_buffer,
             batch_fft_buffer,
             avg_spectrum,
             hanning_window,
@@ -199,15 +210,15 @@ impl FFTProcessor {
         self.actual_data_size = ((self.window_size) as f64 / self.resample_ratio).ceil() as usize;
 
         self.resampler = Some(
-            FftFixedInOut::<f32>::new(
-                self.sample_rate as usize, 
-                11025,
-                self.actual_data_size,
-                1,
-            ).unwrap()
+            FftFixedInOut::<f32>::new(self.sample_rate as usize, 11025, self.actual_data_size, 1)
+                .unwrap(),
         );
-        self.resampler_output_buffer = self.resampler.as_mut().unwrap().output_buffer_allocate(true);
-        
+        self.resampler_output_buffer = self
+            .resampler
+            .as_mut()
+            .unwrap()
+            .output_buffer_allocate(true);
+
         // Decode loop.
         loop {
             // Check for cancellation
@@ -391,13 +402,15 @@ impl FFTProcessor {
         self.total_zcr += zcr(resampled_chunk);
         self.total_energy += energy(resampled_chunk);
 
+        // TODO: Already find one way to optimize this which can be 0.5ms faster in startup_0.ogg
         let start_idx = self.batch_cache_buffer_count * self.window_size;
         for (i, &sample) in resampled_chunk.iter().enumerate() {
             if i >= self.window_size {
                 break;
             }
             let windowed_sample = sample * self.hanning_window[i];
-            self.batch_fft_buffer[start_idx + i] = Complex::new(windowed_sample, 0.0);
+            self.cpu_batch_fft_buffer[start_idx + i] = windowed_sample;
+            // self.batch_fft_buffer[start_idx + i] = Complex::new(windowed_sample, 0.0);
         }
 
         self.batch_cache_buffer_count += 1;
@@ -409,24 +422,44 @@ impl FFTProcessor {
             .expect("CPU computing device not initialized");
 
         if force {
-            cpu_fft.process(&mut self.batch_fft_buffer);
+            let _ = cpu_fft.process(
+                &mut self.cpu_batch_fft_buffer,
+                &mut self.cpu_batch_fft_output_buffer,
+            );
 
             for batch_idx in 0..self.batch_cache_buffer_count {
                 let start = batch_idx * self.window_size;
-                for i in 0..self.window_size {
-                    self.avg_spectrum[i] += self.batch_fft_buffer[start + i];
+                for i in 0..self.window_size / 2 + 1 {
+                    // Copy the real FFT output directly
+                    self.avg_spectrum[i] += self.cpu_batch_fft_output_buffer[i];
+
+                    // Reconstruct the conjugate symmetric part (except DC and Nyquist)
+                    if i > 0 && i < self.window_size / 2 {
+                        self.avg_spectrum[self.window_size - i] +=
+                            self.cpu_batch_fft_output_buffer[i].conj();
+                    }
                 }
             }
 
             self.batch_cache_buffer_count = 0;
         } else if self.batch_cache_buffer_count >= self.batch_size {
-            cpu_fft.process(&mut self.batch_fft_buffer);
+            let _ = cpu_fft.process(
+                &mut self.cpu_batch_fft_buffer,
+                &mut self.cpu_batch_fft_output_buffer,
+            );
 
             for batch_idx in 0..self.batch_size {
                 let start = batch_idx * self.window_size;
 
-                for i in 0..self.window_size {
-                    self.avg_spectrum[i] += self.batch_fft_buffer[start + i];
+                for i in 0..self.window_size / 2 + 1 {
+                    // Copy the real FFT output directly
+                    self.avg_spectrum[i] += self.cpu_batch_fft_output_buffer[i];
+
+                    // Reconstruct the conjugate symmetric part (except DC and Nyquist)
+                    if i > 0 && i < self.window_size / 2 {
+                        self.avg_spectrum[self.window_size - i] +=
+                            self.cpu_batch_fft_output_buffer[i].conj();
+                    }
                 }
             }
 
@@ -475,11 +508,85 @@ mod tests {
     use crate::measure_time;
 
     #[test]
-    fn test_fft_startup_sound() {
+    fn test_rust_fft() {
+        let size = 1024;
+        let mut original_data: Vec<Complex<f32>> = (0..size)
+            .map(|i| Complex::new((i as f32).sin(), 0.0))
+            .collect();
+        let mut fft_data = original_data.clone();
+
+        // Create FFT and IFFT planners
+        let mut planner = FftPlanner::new();
+        let fft = planner.plan_fft_forward(size);
+        let ifft = planner.plan_fft_inverse(size);
+
+        // Perform FFT
+        fft.process(&mut fft_data);
+
+        // Perform inverse FFT
+        ifft.process(&mut fft_data);
+
+        for x in fft_data.iter_mut() {
+            *x /= size as f32;
+        }
+
+        // Compare original and reconstructed data
+        for (orig, reconstructed) in original_data.iter().zip(fft_data.iter()) {
+            let diff = (orig - reconstructed).norm();
+            assert!(
+                diff < 1e-6,
+                "Difference too large: {} vs {}, diff = {}",
+                orig,
+                reconstructed,
+                diff
+            );
+        }
+    }
+
+    #[test]
+    fn test_real_fft() {
+        let size = 1024;
+        // Create real input data
+        let mut real_input: Vec<f32> = (0..size).map(|i| (i as f32).sin()).collect();
+        let mut real_output = real_input.clone();
+
+        // Create real FFT planner
+        let mut planner = RealFftPlanner::<f32>::new();
+        let r2c = planner.plan_fft_forward(size);
+        let c2r = planner.plan_fft_inverse(size);
+
+        // Create complex buffer for FFT output
+        let mut spectrum = r2c.make_output_vec();
+
+        // Perform forward FFT
+        r2c.process(&mut real_input, &mut spectrum).unwrap();
+
+        // Perform inverse FFT
+        c2r.process(&mut spectrum, &mut real_output).unwrap();
+
+        // Scale the output
+        for x in real_output.iter_mut() {
+            *x /= size as f32;
+        }
+
+        // Compare original and reconstructed data
+        for (orig, reconstructed) in real_input.iter().zip(real_output.iter()) {
+            let diff = (orig - reconstructed).abs();
+            assert!(
+                diff < 1e-6,
+                "Difference too large: {} vs {}, diff = {}",
+                orig,
+                reconstructed,
+                diff
+            );
+        }
+    }
+
+    #[test]
+    fn test_fft_cpu_vs_legacy() {
         let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let file_path = "../assets/startup_0.ogg";
         let window_size = 1024;
-        let batch_size = 1024 * 8;
         let overlap_size = 512;
 
         let cpu_result = measure_time!(
@@ -487,6 +594,44 @@ mod tests {
             cpu_fft(file_path, window_size, overlap_size, None)
         )
         .unwrap();
+
+        let legacy_cpu_result = measure_time!(
+            "LEGACY CPU FFT",
+            legacy_fft::fft(file_path, window_size, overlap_size, None)
+        )
+        .unwrap();
+
+        info!("CPU result: {:?}", cpu_result);
+        info!("Legacy CPU result: {:?}", legacy_cpu_result);
+
+        // Compare results with tolerance
+        assert!(
+            (cpu_result.rms - legacy_cpu_result.rms).abs() < 0.001,
+            "RMS difference too large: {} vs {}",
+            cpu_result.rms,
+            legacy_cpu_result.rms
+        );
+        assert!(
+            (cpu_result.energy - legacy_cpu_result.energy).abs() < 1.0,
+            "Energy difference too large: {} vs {}",
+            cpu_result.energy,
+            legacy_cpu_result.energy
+        );
+        assert!(
+            cpu_result.zcr.abs_diff(legacy_cpu_result.zcr) < 10,
+            "ZCR values don't match: {} vs {}",
+            cpu_result.zcr,
+            legacy_cpu_result.zcr
+        );
+    }
+
+    #[test]
+    fn test_fft_gpu_vs_legacy() {
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+        let file_path = "../assets/startup_0.ogg";
+        let window_size = 1024;
+        let batch_size = 1024 * 8;
+        let overlap_size = 512;
 
         let gpu_result = measure_time!(
             "GPU FFT",
@@ -501,7 +646,6 @@ mod tests {
         .unwrap();
 
         info!("GPU result: {:?}", gpu_result);
-        info!("CPU result: {:?}", cpu_result);
         info!("Legacy CPU result: {:?}", legacy_cpu_result);
 
         // Compare results with tolerance
@@ -520,22 +664,67 @@ mod tests {
         assert!(
             gpu_result.zcr.abs_diff(legacy_cpu_result.zcr) < 10,
             "ZCR values don't match: {} vs {}",
-            gpu_result.zcr, legacy_cpu_result.zcr
+            gpu_result.zcr,
+            legacy_cpu_result.zcr
+        );
+    }
+
+    #[test]
+    fn test_fft_cpu_vs_gpu() {
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+        let file_path = "../assets/startup_0.ogg";
+        let window_size = 1024;
+        let batch_size = 1024 * 8;
+        let overlap_size = 512;
+
+        let cpu_result = measure_time!(
+            "CPU FFT",
+            cpu_fft(file_path, window_size, overlap_size, None)
+        )
+        .unwrap();
+
+        let gpu_result = measure_time!(
+            "GPU FFT",
+            gpu_fft(file_path, window_size, batch_size, overlap_size, None)
+        )
+        .unwrap();
+
+        info!("CPU result: {:?}", cpu_result);
+        info!("GPU result: {:?}", gpu_result);
+
+        // Compare results with tolerance
+        assert!(
+            (cpu_result.rms - gpu_result.rms).abs() < 0.001,
+            "RMS difference too large: {} vs {}",
+            cpu_result.rms,
+            gpu_result.rms
+        );
+        assert!(
+            (cpu_result.energy - gpu_result.energy).abs() < 1.0,
+            "Energy difference too large: {} vs {}",
+            cpu_result.energy,
+            gpu_result.energy
+        );
+        assert!(
+            cpu_result.zcr.abs_diff(gpu_result.zcr) < 10,
+            "ZCR values don't match: {} vs {}",
+            cpu_result.zcr,
+            gpu_result.zcr
         );
 
         // Compare spectrum values
-        for (i, (gpu_val, cpu_val)) in gpu_result
+        for (i, (cpu_value, gpu_value)) in cpu_result
             .spectrum
             .iter()
-            .zip(cpu_result.spectrum.iter())
+            .zip(gpu_result.spectrum.iter())
             .enumerate()
         {
             assert!(
-                (gpu_val.norm() - cpu_val.norm()).abs() < 0.001,
+                (cpu_value.norm() - gpu_value.norm()).abs() < 0.001,
                 "Spectrum difference too large at index {}: {} vs {}",
                 i,
-                gpu_val.norm(),
-                cpu_val.norm()
+                cpu_value.norm(),
+                gpu_value.norm()
             );
         }
     }


### PR DESCRIPTION
When testing startup_0.ogg in CPU mode on my m3 max MacBook , this PR can optimize analyze time from  approximately 37+ms -> 36+ms.

~~While working on this PR, I found  one way to speed up(also about 1ms) data preparation during analyze, which will be completed in the next PR.~~
I will do this optimization in the refactoring PR.

After all these, I will refactor the code under the analyze mod.

## Summary by Sourcery

Optimize CPU mode analysis by replacing rustfft with realfft, resulting in improved performance. Update tests to validate the accuracy and performance of the new FFT implementation against legacy and GPU methods.

Enhancements:
- Optimize CPU mode analysis by switching from rustfft to realfft, reducing analysis time by approximately 1ms.

Tests:
- Add new tests to compare the performance and accuracy of real FFT against legacy and GPU implementations, ensuring consistency across different FFT methods.