### PR TITLE
fix: update shortcut alt+N -> option+N on macOS

### DIFF
--- a/lib/widgets/playback_controller/constants/controller_items.dart
+++ b/lib/widgets/playback_controller/constants/controller_items.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:fluent_ui/fluent_ui.dart';
@@ -448,7 +450,9 @@ List<ControllerEntry> controllerItems = [
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(S.of(context).coverWall),
-            const ShortcutText('Alt+N'),
+            ShortcutText(
+              Platform.isMacOS ? '⌥+N' : 'Alt+N'
+            ),
           ],
         ),
         onPressed: () {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the keyboard shortcut display from 'Alt+N' to '⌥+N' for macOS users.