### PR TITLE
fix: using a search character that is only a space would cause an error

### DIFF
--- a/lib/screens/search/search.dart
+++ b/lib/screens/search/search.dart
@@ -135,7 +135,7 @@ class _SearchPageImplementationState extends State<SearchPageImplementation> {
     _lastSearched = task;
     if (_debounce?.isActive ?? false) _debounce!.cancel();
     _debounce = Timer(const Duration(milliseconds: 300), () {
-      if (!_isRequestInProgress) {
+      if (!_isRequestInProgress && searchController.text.trim().isNotEmpty) {
         _performSearch(searchController.text);
       }
     });

--- a/native/hub/src/search.rs
+++ b/native/hub/src/search.rs
@@ -16,16 +16,6 @@ pub async fn search_for_request(
 ) -> Result<()> {
     let request = dart_signal.message;
     let query_str = request.query_str;
-    if query_str.trim().is_empty() {
-        SearchForResponse {
-            artists: Vec::new(),
-            albums: Vec::new(),
-            playlists: Vec::new(),
-            tracks: Vec::new(),
-        }
-        .send_signal_to_dart();
-        return Ok(());
-    }
     let search_fields = convert_to_collection_types(request.fields);
     let n = request.n as usize;
 

--- a/native/hub/src/search.rs
+++ b/native/hub/src/search.rs
@@ -16,6 +16,16 @@ pub async fn search_for_request(
 ) -> Result<()> {
     let request = dart_signal.message;
     let query_str = request.query_str;
+    if query_str.trim().is_empty() {
+        SearchForResponse {
+            artists: Vec::new(),
+            albums: Vec::new(),
+            playlists: Vec::new(),
+            tracks: Vec::new(),
+        }
+        .send_signal_to_dart();
+        return Ok(());
+    }
     let search_fields = convert_to_collection_types(request.fields);
     let n = request.n as usize;
 


### PR DESCRIPTION
![Rune 2024-11-21 15 55 27](https://github.com/user-attachments/assets/dcce1762-a701-47bb-b904-ec4a42ed10dc)

Error screenshot.

## Summary by Sourcery

Bug Fixes:
- Fix an error that occurs when a search query consists only of spaces by returning an empty search result.