### PR TITLE
fix: macos dev install script

### DIFF
--- a/scripts/macos_1_install.sh
+++ b/scripts/macos_1_install.sh
@@ -19,6 +19,8 @@ install_if_missing rustup "rustup" "rustup"
 
 brew install lmdb create-dmg protobuf
 
+rustup-init -y
+. "$HOME/.cargo/env"
 rustup default stable
 rustup target add x86_64-apple-darwin
 rustup target add aarch64-apple-darwin

--- a/scripts/macos_1_install.sh
+++ b/scripts/macos_1_install.sh
@@ -15,11 +15,11 @@ install_if_missing() {
 }
 
 install_if_missing flutter "Flutter" "--cask flutter"
-install_if_missing rustc "Rust" "rust"
-install_if_missing rustup "rustup"
+install_if_missing rustup "rustup" "rustup"
 
 brew install lmdb create-dmg protobuf
 
+rustup default stable
 rustup target add x86_64-apple-darwin
 rustup target add aarch64-apple-darwin
 


### PR DESCRIPTION
- fix rustup install command
- remove brew install rust
- install stable rust using rustup

## Summary by Sourcery

Fix the macOS development installation script by correcting the rustup installation command, removing the Homebrew Rust installation, and setting the default Rust version to stable using rustup.

Bug Fixes:
- Correct the rustup installation command in the macOS development script.

Enhancements:
- Remove the installation of Rust via Homebrew in favor of using rustup.