### PR TITLE
feat(macos): vertical traffic lights

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,8 @@ import 'package:window_manager/window_manager.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter_fullscreen/flutter_fullscreen.dart';
+import 'package:macos_window_utils/macos_window_utils.dart';
+import 'package:macos_window_utils/macos/ns_window_button_type.dart';
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -149,6 +151,8 @@ void main(List<String> arguments) async {
   WindowOptions windowOptions = WindowOptions(
     size: windowSizes[windowSize],
     center: true,
+    titleBarStyle:
+        Platform.isMacOS ? TitleBarStyle.hidden : TitleBarStyle.normal,
   );
 
   windowManager.waitUntilReadyToShow(windowOptions, () async {
@@ -198,6 +202,16 @@ void main(List<String> arguments) async {
       child: const Rune(),
     ),
   );
+
+  if (Platform.isMacOS) {
+    WindowManipulator.overrideStandardWindowButtonPosition(
+        buttonType: NSWindowButtonType.closeButton, offset: const Offset(8, 8));
+    WindowManipulator.overrideStandardWindowButtonPosition(
+        buttonType: NSWindowButtonType.miniaturizeButton,
+        offset: const Offset(8, 28));
+    WindowManipulator.overrideStandardWindowButtonPosition(
+        buttonType: NSWindowButtonType.zoomButton, offset: const Offset(8, 48));
+  }
 }
 
 final rootNavigatorKey = GlobalKey<NavigatorState>();

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,14 +1,18 @@
 import Cocoa
 import FlutterMacOS
+import macos_window_utils
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
-    self.contentViewController = flutterViewController
+    let macOSWindowUtilsViewController = MacOSWindowUtilsViewController()
+    self.contentViewController = macOSWindowUtilsViewController
     self.setFrame(windowFrame, display: true)
 
-    RegisterGeneratedPlugins(registry: flutterViewController)
+    /* Initialize the macos_window_utils plugin */
+    MainFlutterWindowManipulator.start(mainFlutterWindow: self)
+
+    RegisterGeneratedPlugins(registry: macOSWindowUtilsViewController.flutterViewController)
 
     super.awakeFromNib()
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -615,10 +615,10 @@ packages:
     dependency: "direct main"
     description:
       name: macos_window_utils
-      sha256: "3d3982495376077f23556b1e235faab3c6d478fe1238766f824e920708d60eba"
+      sha256: "3534f2af024f2f24112ca28789a44e6750083f8c0065414546c6593ee48a5009"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "1.6.1"
   macros:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary by Sourcery

Implement vertical traffic lights for macOS by adjusting the position of window control buttons using the macos_window_utils package. Enhance the window management by setting a hidden title bar style for macOS.

New Features:
- Introduce vertical traffic lights for macOS by adjusting the position of window control buttons.

Enhancements:
- Utilize the macos_window_utils package to manage window button positions and styles on macOS.