### PR TITLE
fix: macOS hide title bar and fix window moving via enable moving by background

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -160,7 +160,7 @@ void main(List<String> arguments) async {
 
   $closeManager;
 
-  if (Platform.isMacOS) {
+  if (Platform.isMacOS) {    
     WindowManipulator.overrideStandardWindowButtonPosition(
         buttonType: NSWindowButtonType.closeButton, offset: const Offset(8, 8));
     WindowManipulator.overrideStandardWindowButtonPosition(
@@ -292,15 +292,17 @@ class _RuneState extends State<Rune> {
           builder: (context, child) {
             final theme = FluentTheme.of(context);
 
-            return Container(
-              color: appTheme.windowEffect == WindowEffect.solid
-                  ? theme.micaBackgroundColor
-                  : Colors.transparent,
-              child: Directionality(
-                textDirection: appTheme.textDirection,
-                child: Shortcuts(
-                  shortcuts: shortcuts,
-                  child: NavigationShortcutManager(RuneLifecycle(child!)),
+            return MoveWindow(
+              child: Container(
+                color: appTheme.windowEffect == WindowEffect.solid
+                    ? theme.micaBackgroundColor
+                    : Colors.transparent,
+                child: Directionality(
+                  textDirection: appTheme.textDirection,
+                  child: Shortcuts(
+                    shortcuts: shortcuts,
+                    child: NavigationShortcutManager(RuneLifecycle(child!)),
+                  ),
                 ),
               ),
             );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -292,20 +292,24 @@ class _RuneState extends State<Rune> {
           builder: (context, child) {
             final theme = FluentTheme.of(context);
 
-            return MoveWindow(
-              child: Container(
-                color: appTheme.windowEffect == WindowEffect.solid
-                    ? theme.micaBackgroundColor
-                    : Colors.transparent,
-                child: Directionality(
-                  textDirection: appTheme.textDirection,
-                  child: Shortcuts(
-                    shortcuts: shortcuts,
-                    child: NavigationShortcutManager(RuneLifecycle(child!)),
-                  ),
+            Widget content = Container(
+              color: appTheme.windowEffect == WindowEffect.solid
+                  ? theme.micaBackgroundColor
+                  : Colors.transparent,
+              child: Directionality(
+                textDirection: appTheme.textDirection,
+                child: Shortcuts(
+                  shortcuts: shortcuts,
+                  child: NavigationShortcutManager(RuneLifecycle(child!)),
                 ),
               ),
             );
+
+            if (Platform.isMacOS) {
+              content = MoveWindow(child: content);
+            }
+
+            return content;
           },
         );
       },

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,8 +1,13 @@
 import Cocoa
 import FlutterMacOS
 import macos_window_utils
+import bitsdojo_window_macos
 
-class MainFlutterWindow: NSWindow {
+class MainFlutterWindow: BitsdojoWindow {
+  override func bitsdojo_window_configure() -> UInt {
+    return BDW_CUSTOM_FRAME | BDW_HIDE_ON_STARTUP
+  }
+
   override func awakeFromNib() {
     let windowFrame = self.frame
     let macOSWindowUtilsViewController = MacOSWindowUtilsViewController()


### PR DESCRIPTION
**WARNING: Please test the app before merging.**

If we use the library `bitsdojo_window` to hide the titlebar on macOS. Then we need to handle the window dragging by our hand.

For macOS app, being able to drag windows from anywhere in the background is not a very rare design. So, I implemented the same design.

However, I'm not sure if this is acceptable to the project owner @Losses .

## Summary by Sourcery

Fix window dragging on macOS by using the bitsdojo_window library to hide the title bar and enable dragging from the background.

Bug Fixes:
- Fix window dragging functionality on macOS by implementing custom window dragging using the bitsdojo_window library.

Enhancements:
- Enhance the macOS app by hiding the title bar and allowing window dragging from the background.