### PR TITLE
fix: Window size on macOS

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -177,7 +177,7 @@ void main(List<String> arguments) async {
       await settingsManager.getValue<String>(windowSizeKey) ?? 'normal';
 
   final firstView = WidgetsBinding.instance.platformDispatcher.views.first;
-  final windowSize = Platform.isWindows
+  final windowSize = Platform.isWindows || Platform.isMacOS
       ? windowSizes[windowSizeSetting]!
       : windowSizes[windowSizeSetting]! / firstView.devicePixelRatio;
   appWindow.size = windowSize;

--- a/lib/screens/settings_theme/settings_theme.dart
+++ b/lib/screens/settings_theme/settings_theme.dart
@@ -119,7 +119,7 @@ class _SettingsThemeState extends State<SettingsTheme> {
     await SettingsManager().setValue(windowSizeKey, newWindowSize);
 
     final firstView = WidgetsBinding.instance.platformDispatcher.views.first;
-    final size = Platform.isWindows
+    final size = Platform.isWindows || Platform.isMacOS
         ? windowSizes[newWindowSize]!
         : windowSizes[newWindowSize]! / firstView.devicePixelRatio;
     appWindow.size = size;


### PR DESCRIPTION
Make macOS’s window behavior works like windows.

After alpha 11 the rune's window on macOS is very small in normal mode.

![CleanShot 2024-11-25 at 18 50 34@2x](https://github.com/user-attachments/assets/66c27e21-e290-421d-97aa-cb2c8738d979)

This PR makes windows on macOS work like they did before alpha 11.

![CleanShot 2024-11-25 at 18 53 20@2x](https://github.com/user-attachments/assets/2f0b96c6-beb2-4591-8959-6553857b68c8)

## Summary by Sourcery

Bug Fixes:
- Fix window size behavior on macOS to match the behavior on Windows, ensuring consistent window sizing across platforms.