### PR TITLE
fix: Escape button via deleting useless macOS specific WindowTitleBarBox

### DIFF
--- a/lib/widgets/navigation_bar/navigation_bar.dart
+++ b/lib/widgets/navigation_bar/navigation_bar.dart
@@ -186,10 +186,6 @@ class NavigationBarState extends State<NavigationBar> {
 
         return Stack(
           children: [
-            if (Platform.isMacOS)
-              WindowTitleBarBox(
-                child: Container(width: 28),
-              ),
             if (isZune || !isSearch)
               Transform.translate(
                 offset: const Offset(0, -40),


### PR DESCRIPTION
close #118

After reading the code and during experiments, I believe the deleted macOS specific WindowTitleBarBox is legacy and is the cause of #118. Therefore, I removed it to solve that issue.

## Summary by Sourcery

Bug Fixes:
- Remove the macOS specific WindowTitleBarBox to fix the issue causing the Escape button malfunction.