### PR TITLE
feat: Redesign macOS move area

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:intl/intl_standalone.dart';
+import 'package:rune/widgets/navigation_bar/utils/macos_move_window.dart';
 import 'package:tray_manager/tray_manager.dart';
 import 'package:system_theme/system_theme.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
@@ -275,11 +276,32 @@ class _RuneState extends State<Rune> {
           onGenerateRoute: (settings) {
             final routeName = settings.name!;
 
-            if (routeName == '/' || routeName == '/scanning') {
-              return NoEffectPageRoute<dynamic>(
-                settings: settings,
-                builder: (context) => WindowFrame(routes[routeName]!(context)),
-              );
+            if (!Platform.isMacOS) {
+              if (routeName == '/' || routeName == '/scanning') {
+                return NoEffectPageRoute<dynamic>(
+                  settings: settings,
+                  builder: (context) =>
+                      WindowFrame(routes[routeName]!(context)),
+                );
+              }
+            } else {
+              if (routeName == '/scanning') {
+                return NoEffectPageRoute<dynamic>(
+                  settings: settings,
+                  builder: (context) => MacOSMoveWindow(
+                    child: WindowFrame(routes[routeName]!(context)),
+                  ),
+                );
+              }
+              if (routeName == '/') {
+                return NoEffectPageRoute<dynamic>(
+                  settings: settings,
+                  builder: (context) => MacOSMoveWindow(
+                    isEnabledDoubleTap: false,
+                    child: WindowFrame(routes[routeName]!(context)),
+                  ),
+                );
+              }
             }
 
             final page = RuneWithNavigationBarAndPlaybackControllor(
@@ -327,10 +349,6 @@ class _RuneState extends State<Rune> {
                 ),
               ),
             );
-
-            if (Platform.isMacOS) {
-              content = MoveWindow(child: content);
-            }
 
             return content;
           },

--- a/lib/widgets/navigation_bar/navigation_bar.dart
+++ b/lib/widgets/navigation_bar/navigation_bar.dart
@@ -162,7 +162,7 @@ class NavigationBarState extends State<NavigationBar> {
                         ],
                       ),
                     )
-                  : IntrinsicHeight(child: Expanded(child: MoveWindow));
+                  : IntrinsicHeight(child: MoveWindow);
             });
 
         final baseSlibings = (slibings ?? emptySlibings);

--- a/lib/widgets/navigation_bar/navigation_bar.dart
+++ b/lib/widgets/navigation_bar/navigation_bar.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:provider/provider.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:rune/widgets/navigation_bar/utils/macos_move_window.dart';
 
 import '../../utils/router/navigation.dart';
 import '../../utils/navigation/navigation_item.dart';
@@ -135,6 +136,35 @@ class NavigationBarState extends State<NavigationBar> {
                   : Container();
             });
 
+        late Widget macOSParentWidget = SmallerOrEqualTo(
+            deviceType: DeviceType.fish,
+            builder: (context, isFish) {
+              final movableParentWidget = MacOSMoveWindow(
+                  isEnabledDoubleTap: false, child: parentWidget);
+
+              if (isFish) {
+                return MacOSMoveWindow(
+                    isEnabledDoubleTap: false, child: movableParentWidget);
+              }
+
+              final MoveWindow = MacOSMoveWindow(
+                child: Container(
+                  height: 80,
+                ),
+              );
+
+              return parent != null
+                  ? IntrinsicHeight(
+                      child: Row(
+                        children: [
+                          movableParentWidget,
+                          Expanded(child: MoveWindow)
+                        ],
+                      ),
+                    )
+                  : IntrinsicHeight(child: Expanded(child: MoveWindow));
+            });
+
         final baseSlibings = (slibings ?? emptySlibings);
         final validSlibings = isZune
             ? baseSlibings
@@ -181,7 +211,50 @@ class NavigationBarState extends State<NavigationBar> {
           },
         );
 
+        final macOSChildrenWidget = SmallerOrEqualTo(
+          deviceType: DeviceType.fish,
+          builder: (context, isFish) {
+            final movableChildrenWidget = MacOSMoveWindow(
+              isEnabledDoubleTap: false,
+              child: childrenWidget,
+            );
+
+            final MoveWindow = MacOSMoveWindow();
+
+            return parent != null
+                ? IntrinsicHeight(
+                    child: Row(
+                      children: [
+                        movableChildrenWidget,
+                        Expanded(child: MoveWindow)
+                      ],
+                    ),
+                  )
+                : IntrinsicHeight(
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 0,
+                          child: movableChildrenWidget,
+                        ),
+                        Expanded(child: MoveWindow)
+                      ],
+                    ),
+                  );
+          },
+        );
+
         final isSearch = path == '/search';
+
+        final navigationContent = Platform.isMacOS
+            ? [
+                macOSParentWidget,
+                macOSChildrenWidget,
+              ]
+            : [
+                parentWidget,
+                childrenWidget,
+              ];
 
         return Stack(
           children: [
@@ -196,10 +269,7 @@ class NavigationBarState extends State<NavigationBar> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       mainAxisSize: MainAxisSize.max,
-                      children: [
-                        parentWidget,
-                        childrenWidget,
-                      ],
+                      children: navigationContent,
                     ),
                   ),
                 ),

--- a/lib/widgets/navigation_bar/utils/macos_move_window.dart
+++ b/lib/widgets/navigation_bar/utils/macos_move_window.dart
@@ -1,0 +1,55 @@
+import 'package:bitsdojo_window/bitsdojo_window.dart';
+import 'package:fluent_ui/fluent_ui.dart';
+
+class MacOSMoveWindow extends StatelessWidget {
+  final Widget? child;
+  final bool isEnabledDoubleTap;
+  final VoidCallback? onDoubleTap;
+
+  MacOSMoveWindow({
+    Key? key,
+    this.child,
+    this.isEnabledDoubleTap = true,
+    this.onDoubleTap,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (child == null) {
+      return _MacOSMoveWindow(
+          isEnabledDoubleTap: isEnabledDoubleTap,
+          onDoubleTap: onDoubleTap);
+    }
+    return _MacOSMoveWindow(
+      isEnabledDoubleTap: isEnabledDoubleTap,
+      onDoubleTap: onDoubleTap,
+      child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [Expanded(child: child!)]),
+    );
+  }
+}
+
+class _MacOSMoveWindow extends StatelessWidget {
+  _MacOSMoveWindow({
+    Key? key,
+    this.child,
+    this.isEnabledDoubleTap = true,
+    this.onDoubleTap,
+  }) : super(key: key);
+  final Widget? child;
+  final bool isEnabledDoubleTap;
+  final VoidCallback? onDoubleTap;
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onPanStart: (details) {
+          appWindow.startDragging();
+        },
+        onDoubleTap: isEnabledDoubleTap
+            ? this.onDoubleTap ?? () => appWindow.maximizeOrRestore()
+            : null,
+        child: this.child ?? Container());
+  }
+}

--- a/lib/widgets/router/rune_router_frame_implementation.dart
+++ b/lib/widgets/router/rune_router_frame_implementation.dart
@@ -1,5 +1,9 @@
+import 'dart:io';
+
 import 'package:provider/provider.dart';
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:rune/screens/cover_wall/widgets/playing_track.dart';
+import 'package:rune/widgets/navigation_bar/utils/macos_move_window.dart';
 
 import '../../main.dart';
 
@@ -84,6 +88,25 @@ class _RuneRouterFrameImplementationState
                     ? Alignment.centerRight
                     : Alignment.bottomCenter,
                 children: [
+                  // macos move window in small view
+                  if (Platform.isMacOS)
+                    DeviceTypeBuilder(
+                        deviceType: const [
+                          DeviceType.band,
+                          DeviceType.dock,
+                          DeviceType.tv
+                        ],
+                        builder: (context, activeBreakpoint) {
+                          final isSmallView =
+                              activeBreakpoint == DeviceType.band ||
+                                  activeBreakpoint == DeviceType.dock;
+                          if (isSmallView) {
+                            return MacOSMoveWindow(
+                              isEnabledDoubleTap: false,
+                            );
+                          }
+                          return Container();
+                        }),
                   if (path == '/cover_wall' && !showDisk) mainContent,
                   if (!showDisk)
                     const FocusTraversalOrder(


### PR DESCRIPTION
## Summary by Sourcery

Redesign the macOS move area by introducing a new MacOSMoveWindow widget to manage window movement and double-tap actions. Enhance the navigation bar and routing logic to utilize this widget, improving window management and user experience on macOS.

New Features:
- Introduce a new MacOSMoveWindow widget to handle window movement and double-tap actions on macOS.

Enhancements:
- Redesign the navigation bar to incorporate the new MacOSMoveWindow widget for better window management on macOS.
- Update routing logic to use MacOSMoveWindow for specific routes on macOS, enhancing the user experience by allowing window movement.