### PR TITLE
fix(macOS): Vertically arranged window control buttons not work

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,8 +13,6 @@ import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter_fullscreen/flutter_fullscreen.dart';
-import 'package:macos_window_utils/macos_window_utils.dart';
-import 'package:macos_window_utils/macos/ns_window_button_type.dart';
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,13 +6,13 @@ import 'package:provider/provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:intl/intl_standalone.dart';
-import 'package:rune/utils/macos_window_control_button_manager.dart';
 import 'package:tray_manager/tray_manager.dart';
 import 'package:system_theme/system_theme.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter_fullscreen/flutter_fullscreen.dart';
+import 'package:rune/utils/macos_window_control_button_manager.dart';
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:intl/intl_standalone.dart';
+import 'package:rune/utils/macos_window_control_button_manager.dart';
 import 'package:tray_manager/tray_manager.dart';
 import 'package:system_theme/system_theme.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
@@ -164,13 +165,7 @@ void main(List<String> arguments) async {
   $closeManager;
 
   if (Platform.isMacOS) {
-    WindowManipulator.overrideStandardWindowButtonPosition(
-        buttonType: NSWindowButtonType.closeButton, offset: const Offset(8, 8));
-    WindowManipulator.overrideStandardWindowButtonPosition(
-        buttonType: NSWindowButtonType.miniaturizeButton,
-        offset: const Offset(8, 28));
-    WindowManipulator.overrideStandardWindowButtonPosition(
-        buttonType: NSWindowButtonType.zoomButton, offset: const Offset(8, 48));
+    MacOSWindowControlButtonManager.setVertical();
   }
 
   final windowSizeSetting =

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,6 @@ import 'package:flutter_acrylic/flutter_acrylic.dart';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter_fullscreen/flutter_fullscreen.dart';
-import 'package:rune/utils/macos_window_control_button_manager.dart';
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -30,6 +29,7 @@ import 'utils/update_color_mode.dart';
 import 'utils/theme_color_manager.dart';
 import 'utils/storage_key_manager.dart';
 import 'utils/file_storage/mac_secure_manager.dart';
+import 'utils/macos_window_control_button_manager.dart';
 
 import 'config/theme.dart';
 import 'config/routes.dart';

--- a/lib/utils/macos_window_control_button_manager.dart
+++ b/lib/utils/macos_window_control_button_manager.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/services.dart';
+
+class MacOSWindowControlButtonManager {
+  static const platform = MethodChannel('not.ci.rune/window_control_button');
+
+  static Future<void> setVertical() async {
+    await platform.invokeMethod('set_vertical');
+  }
+}

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,7 +1,8 @@
+import AppKit
 import Cocoa
 import FlutterMacOS
-import macos_window_utils
 import bitsdojo_window_macos
+import macos_window_utils
 
 class MainFlutterWindow: BitsdojoWindow {
   override func bitsdojo_window_configure() -> UInt {
@@ -17,8 +18,68 @@ class MainFlutterWindow: BitsdojoWindow {
     /* Initialize the macos_window_utils plugin */
     MainFlutterWindowManipulator.start(mainFlutterWindow: self)
 
+    let windowControlButtonChannel = FlutterMethodChannel(
+      name: "not.ci.rune/window_control_button",
+      binaryMessenger: macOSWindowUtilsViewController.flutterViewController.engine.binaryMessenger)
+    windowControlButtonChannel.setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "set_vertical":
+        WindowButtonPositioner.shared.setVertical()
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     RegisterGeneratedPlugins(registry: macOSWindowUtilsViewController.flutterViewController)
 
+    WindowButtonPositioner.shared.mainFlutterWindow = self
+
     super.awakeFromNib()
+  }
+}
+
+class WindowButtonPositioner {
+  static let shared = WindowButtonPositioner()
+
+  var mainFlutterWindow: NSWindow? = nil
+
+  init() {}
+
+  init(mainFlutterWindow: NSWindow) {
+    self.mainFlutterWindow = mainFlutterWindow
+  }
+
+  func setVertical() {
+    overrideStandardWindowButtonPosition(buttonType: .closeButton, offset: .init(x: 8, y: 8))
+    overrideStandardWindowButtonPosition(buttonType: .miniaturizeButton, offset: .init(x: 8, y: 28))
+    overrideStandardWindowButtonPosition(buttonType: .zoomButton, offset: .init(x: 8, y: 48))
+  }
+
+  func overrideStandardWindowButtonPosition(
+    buttonType: NSWindow.ButtonType, offset: CGPoint
+  ) {
+    guard let standardWindowButton = mainFlutterWindow!.standardWindowButton(buttonType) else {
+      return
+    }
+
+    standardWindowButton.removeFromSuperview()
+
+    guard let contentView: NSView = mainFlutterWindow!.contentView else {
+      return
+    }
+
+    contentView.addSubview(standardWindowButton)
+
+    standardWindowButton.translatesAutoresizingMaskIntoConstraints = false
+    standardWindowButton.wantsLayer = true
+
+    NSLayoutConstraint.activate([
+      standardWindowButton.leadingAnchor.constraint(
+        equalTo: contentView.leadingAnchor, constant: offset.x),
+      standardWindowButton.topAnchor.constraint(
+        equalTo: contentView.topAnchor, constant: offset.y),
+    ])
+
+    contentView.layoutSubtreeIfNeeded()
   }
 }

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -2,7 +2,6 @@ import AppKit
 import Cocoa
 import FlutterMacOS
 import bitsdojo_window_macos
-import macos_window_utils
 
 class MainFlutterWindow: BitsdojoWindow {
   override func bitsdojo_window_configure() -> UInt {
@@ -10,17 +9,14 @@ class MainFlutterWindow: BitsdojoWindow {
   }
 
   override func awakeFromNib() {
+    let flutterViewController = FlutterViewController.init()
     let windowFrame = self.frame
-    let macOSWindowUtilsViewController = MacOSWindowUtilsViewController()
-    self.contentViewController = macOSWindowUtilsViewController
+    self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)
-
-    /* Initialize the macos_window_utils plugin */
-    MainFlutterWindowManipulator.start(mainFlutterWindow: self)
 
     let windowControlButtonChannel = FlutterMethodChannel(
       name: "not.ci.rune/window_control_button",
-      binaryMessenger: macOSWindowUtilsViewController.flutterViewController.engine.binaryMessenger)
+      binaryMessenger: flutterViewController.engine.binaryMessenger)
     windowControlButtonChannel.setMethodCallHandler { (call, result) in
       switch call.method {
       case "set_vertical":
@@ -30,7 +26,7 @@ class MainFlutterWindow: BitsdojoWindow {
       }
     }
 
-    RegisterGeneratedPlugins(registry: macOSWindowUtilsViewController.flutterViewController)
+    RegisterGeneratedPlugins(registry: flutterViewController)
 
     WindowButtonPositioner.shared.mainFlutterWindow = self
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -660,7 +660,7 @@ packages:
     source: hosted
     version: "0.2.1"
   macos_window_utils:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: macos_window_utils
       sha256: "3534f2af024f2f24112ca28789a44e6750083f8c0065414546c6593ee48a5009"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,6 @@ dependencies:
   flutter_boring_avatars: ^2.0.1
   logger: ^2.4.0
   flutter_svg: ^2.0.10+1
-  macos_window_utils: ^1.5.0
   rinf: ^7.0.2
   fixnum: ^1.1.0
   very_good_infinite_list: ^0.9.0


### PR DESCRIPTION
fix #105

![CleanShot 2024-11-27 at 02 51 22@2x](https://github.com/user-attachments/assets/8d6dddb1-a39f-4f14-aa6d-9fa0329a47b6)

## Summary by Sourcery

Bug Fixes:
- Fix the issue with vertically arranged window control buttons not working on macOS by implementing a method to set their positions.