### PR TITLE
fix: Inappropriate translation in lzh and hans

### DIFF
--- a/lib/l10n/intl_zh_Hans.arb
+++ b/lib/l10n/intl_zh_Hans.arb
@@ -829,7 +829,7 @@
     "@evaluationMode": {
         "description": "评估模式模态框的标题"
     },
-    "evaluationModeContent1": "Rune 不是免费的午餐。我们鼓励您从应用商店购买正版许可证。",
+    "evaluationModeContent1": "Rune 不是免费软件。我们鼓励您从应用商店购买正版许可证。",
     "@evaluationModeContent1": {
         "description": "评估模式模态框的内容"
     },

--- a/lib/l10n/intl_zh_Hant_LZH.arb
+++ b/lib/l10n/intl_zh_Hant_LZH.arb
@@ -829,11 +829,11 @@
   "@evaluationMode": {
     "description": "Title of the evaluation mode modal"
   },
-  "evaluationModeContent1": "符聆並非道邊李，望君購執於肆集。",
+  "evaluationModeContent1": "符聆並非無償物，望君購執於市鋪。",
   "@evaluationModeContent1": {
     "description": "Content of the evaluation mode modal"
   },
-  "evaluationModeContent2": "夫執者，得享自更新之於肆，且有權直語著者所望。",
+  "evaluationModeContent2": "夫執者，得享自更新之於市，且有權直語著者所望。",
   "@evaluationModeContent2": {
     "description": "Content of the evaluation mode modal"
   },


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct inappropriate translations in Simplified Chinese (Hans) and Classical Chinese (LZH) localization files.