### PR TITLE
fix(macOS): Traffic light isn’t vertical in first time open

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -167,10 +167,6 @@ void main(List<String> arguments) async {
     shortcutPolicy: ShortcutPolicy.requireCreate,
   );
 
-  if (Platform.isMacOS) {
-    MacOSWindowControlButtonManager.setVertical();
-  }
-
   final windowSizeMode =
       await settingsManager.getValue<String>(windowSizeKey) ?? 'normal';
   final bool? rememberWindowSize =
@@ -206,6 +202,11 @@ void main(List<String> arguments) async {
     appWindow.size = windowSize;
     appWindow.alignment = Alignment.center;
     appWindow.show();
+
+    // TODO: After rewrite bitdojo_window, move this code to NSWindowController.windowWillLoad
+    if (Platform.isMacOS) {
+      MacOSWindowControlButtonManager.setVertical();
+    }
 
     if (storedFullScreen != null) {
       FullScreen.setFullScreen(storedFullScreen);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -193,20 +193,21 @@ void main(List<String> arguments) async {
   }
 
   mainLoop(licenseProvider);
-  appWindow.show();
+  if (!Platform.isMacOS) {
+    appWindow.show();
+  }
 
   bool? storedFullScreen =
       await settingsManager.getValue<bool>('fullscreen_state');
 
   doWhenWindowReady(() {
-    appWindow.size = windowSize;
-    appWindow.alignment = Alignment.center;
-    appWindow.show();
-
-    // TODO: After rewrite bitdojo_window, move this code to NSWindowController.windowWillLoad
     if (Platform.isMacOS) {
       MacOSWindowControlButtonManager.setVertical();
     }
+
+    appWindow.size = windowSize;
+    appWindow.alignment = Alignment.center;
+    appWindow.show();
 
     if (storedFullScreen != null) {
       FullScreen.setFullScreen(storedFullScreen);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the issue where the traffic light buttons on macOS were not vertical when the application was opened for the first time.