### PR TITLE
fix(macos):  The display of the tray

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -162,7 +162,7 @@ void main(List<String> arguments) async {
   );
 
   await systemTray.initSystemTray(
-    title: 'Rune',
+    title: Platform.isMacOS ? null : 'Rune',
     iconPath: TrayManager.getTrayIconPath(),
     isTemplate: true,
   );


### PR DESCRIPTION
Only show one icon to take up less space

## Summary by Sourcery

Bug Fixes:
- Fix the display of the tray icon on macOS by removing the title to ensure only one icon is shown.