### PR TITLE
fix(macos, notarized): Notarized build use Developer ID

### DIFF
--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -591,7 +591,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "3rd Party Mac Developer Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
@@ -612,7 +612,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.14.6;
 				PRODUCT_BUNDLE_IDENTIFIER = ci.not.rune;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "Rune App Store";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "Rune Notarized";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Profile;
@@ -770,7 +770,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "3rd Party Mac Developer Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
@@ -791,7 +791,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.14.6;
 				PRODUCT_BUNDLE_IDENTIFIER = ci.not.rune;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "Rune App Store";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "Rune Notarized";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/scripts/macos_2_appstore_build.sh
+++ b/scripts/macos_2_appstore_build.sh
@@ -11,7 +11,7 @@ cp macos/Runner.xcodeproj/project.pbxproj macos/Runner.xcodeproj/project.pbxproj
 # Patch macos/Runner.xcodeproj/project.pbxproj and macos/Runner/Release.entitlements to replace bundle ID and provisioning profile
 sed -i '' 's/PRODUCT_BUNDLE_IDENTIFIER = ci.not.rune;/PRODUCT_BUNDLE_IDENTIFIER = ci.not.rune.appstore;/g' macos/Runner.xcodeproj/project.pbxproj
 sed -i '' 's/PROVISIONING_PROFILE_SPECIFIER = "Rune Notarized";/PROVISIONING_PROFILE_SPECIFIER = "Rune App Store";/g' macos/Runner.xcodeproj/project.pbxproj
-sed -i '' 's/"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";/"CODE_SIGN_IDENTITY[sdk=macosx*]" = "3rd Party Mac Developer Application";/g'
+sed -i '' 's/"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";/"CODE_SIGN_IDENTITY[sdk=macosx*]" = "3rd Party Mac Developer Application";/g' macos/Runner.xcodeproj/project.pbxproj
 sed -i '' 's/<string>LG57TUQ726.ci.not.rune<\/string>/<string>LG57TUQ726.ci.not.rune.appstore<\/string>/g' macos/Runner/Release.entitlements
 
 flutter pub get

--- a/scripts/macos_2_appstore_build.sh
+++ b/scripts/macos_2_appstore_build.sh
@@ -8,8 +8,10 @@ cd ..
 # Create backup of project.pbxproj
 cp macos/Runner.xcodeproj/project.pbxproj macos/Runner.xcodeproj/project.pbxproj.backup
 
-# Patch macos/Runner.xcodeproj/project.pbxproj and macos/Runner/Release.entitlements to replace bundle ID
+# Patch macos/Runner.xcodeproj/project.pbxproj and macos/Runner/Release.entitlements to replace bundle ID and provisioning profile
 sed -i '' 's/PRODUCT_BUNDLE_IDENTIFIER = ci.not.rune;/PRODUCT_BUNDLE_IDENTIFIER = ci.not.rune.appstore;/g' macos/Runner.xcodeproj/project.pbxproj
+sed -i '' 's/PROVISIONING_PROFILE_SPECIFIER = "Rune Notarized";/PROVISIONING_PROFILE_SPECIFIER = "Rune App Store";/g' macos/Runner.xcodeproj/project.pbxproj
+sed -i '' 's/"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";/"CODE_SIGN_IDENTITY[sdk=macosx*]" = "3rd Party Mac Developer Application";/g'
 sed -i '' 's/<string>LG57TUQ726.ci.not.rune<\/string>/<string>LG57TUQ726.ci.not.rune.appstore<\/string>/g' macos/Runner/Release.entitlements
 
 flutter pub get


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the code signing identity and provisioning profile for notarized macOS builds to use the Developer ID.