### PR TITLE
fix: macos build and linux build

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -7,7 +7,7 @@ macos-ci-all: macos-ci-clean macos-ci-install
 
 macos-ci-all-appstore: macos-ci-clean macos-ci-install
   ./scripts/macos_2_appstore_build.sh
-  ./scripts/macos_3_prepare_before_sign.sh
+  ./scripts/macos_3_prepare_before_sign_for_appstore.sh
   ./scripts/macos_4_replace_dylib.sh
   ./scripts/macos_5_codesign_and_submit_to_appstore.sh
 

--- a/native/hub/build.rs
+++ b/native/hub/build.rs
@@ -19,11 +19,13 @@ fn main() -> Result<()> {
         .add_instructions(&rustc)?
         .emit()?;
 
+    #[cfg(target_os = "macos")]    
     apple_bridge::build_apple_bridge_library();
 
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
 pub mod apple_bridge {
     use std::path::PathBuf;
     use std::process::Command;

--- a/scripts/macos_3_prepare_before_sign_for_appstore.sh
+++ b/scripts/macos_3_prepare_before_sign_for_appstore.sh
@@ -11,3 +11,4 @@ mkdir temp_macos
 ditto build/macos/Build/Products/Release/Rune.app temp_macos/Rune.app
 cp macos/Runner/Release.entitlements temp_macos
 
+cp ~/Library/MobileDevice/Provisioning\ Profiles/*.provisionprofile temp_macos/Rune.app/Contents/embedded.provisionprofile


### PR DESCRIPTION
## Summary by Sourcery

Fix the macOS build process by updating the script for App Store preparation and enhance the build script with macOS-specific conditional compilation.

Bug Fixes:
- Fix the macOS build process by updating the script used for preparing the app before signing for the App Store.

Enhancements:
- Add conditional compilation for macOS in the build script to ensure the apple_bridge library is only built on macOS.