### PR TITLE
fix(build): standardize archive naming conventions for tag and manual builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: build/windows/x64/runner/Release/
-          name: Rune-${{ github.ref_name }}-${{ steps.short-sha.outputs.sha }}-windows
+          name: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-windows
 
   release-windows:
     permissions:
@@ -79,7 +79,7 @@ jobs:
         uses: thedoctor0/zip-release@master
         with:
           type: "zip"
-          filename: Rune-${{ github.ref_name }}-${{ steps.short-sha.outputs.sha }}-windows-amd64.zip
+          filename: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-windows-amd64.zip
           directory: artifacts
 
       - name: Release
@@ -142,7 +142,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: build/linux/x64/release/bundle/
-          name: Rune-${{ github.ref_name }}-${{ steps.short-sha.outputs.sha }}-linux
+          name: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-linux
 
   build-steam-sniper:
     runs-on: ubuntu-latest
@@ -207,7 +207,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: build/linux/x64/release/bundle/
-          name: Rune-${{ github.ref_name }}-${{ steps.short-sha.outputs.sha }}-steam-sniper
+          name: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-steam-sniper
 
   release-linux:
     permissions:
@@ -231,7 +231,7 @@ jobs:
         uses: thedoctor0/zip-release@master
         with:
           type: "zip"
-          filename: Rune-${{ github.ref_name }}-${{ steps.short-sha.outputs.sha }}-linux-amd64.zip
+          filename: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-linux-amd64.zip
           directory: artifacts
 
       - name: Release
@@ -265,7 +265,7 @@ jobs:
         uses: thedoctor0/zip-release@master
         with:
           type: "zip"
-          filename: Rune-${{ github.ref_name }}-${{ steps.short-sha.outputs.sha }}-steam-sniper-amd64.zip
+          filename: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-steam-sniper-amd64.zip
           directory: artifacts
 
       - name: Release
@@ -360,7 +360,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: "temp_macos/*.dmg"
-          name: Rune-${{ github.ref_name }}-${{ steps.short-sha.outputs.sha }}-macOS
+          name: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS
 
       - name: Clean up
         if: ${{ always() }}


### PR DESCRIPTION
### Context
Previously, archives built during tag-based releases included the short SHA in their filenames (e.g., `Rune-v0.0.0-alpha.16<shortsha>-windows-amd64.zip`). While this helped in identifying builds, it introduced usability challenges, particularly when users tried to install specific versions without access to the SHA, especially for scoop.

This PR adjusts the naming convention:
- Tag-based builds now exclude the short SHA, producing predictable filenames (e.g., `Rune-v0.0.0-alpha.16-windows-amd64.zip`).
- For manually triggered builds (not associated with tags) or continuous builds, the short SHA is retained in the archive names to prevent potential filename collisions.

### Changes Made
1. Removed the short SHA from archive filenames for tag-based builds.
2. Retained short SHA for manually triggered builds or builds without specific tags.

---

### Impact
- Tag-based builds will now always produce predictable filenames like `Rune-v0.0.0-alpha.20-windows-amd64.zip`.
- Manually triggered builds will retain short SHA in filenames to avoid conflicts.

## Summary by Sourcery

Standardize archive naming conventions by removing the short SHA from filenames for tag-based builds to improve usability, while retaining it for manually triggered builds to prevent filename collisions.

Bug Fixes:
- Standardize archive naming conventions by removing the short SHA from filenames for tag-based builds to improve usability.

Build:
- Modify build scripts to exclude the short SHA from archive filenames for tag-based builds while retaining it for manually triggered builds.