### PR TITLE
fix(ci): only run build-and-release-mac-app-store if releasing new version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -455,6 +455,7 @@ jobs:
 
   build-and-release-mac-app-store:
     runs-on: macos-latest
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Restrict the 'build-and-release-mac-app-store' job to only run when a new version is being released by checking if the Git reference starts with 'refs/tags/v'.