### PR TITLE
fix(macos): resolve filename conflict and remove nested ZIP structure for DMG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,7 +393,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: "temp_macos/*.zip"
-          name: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS
+          name: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS-zip
 
       - name: Clean up
         if: ${{ always() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -394,7 +394,7 @@ jobs:
       - name: Upload artifact macOS DMG
         uses: actions/upload-artifact@v4
         with:
-          path: temp_macos/temp_macos/Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS.dmg
+          path: temp_macos/Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS.dmg
           name: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS.dmg
 
       - name: Upload artifact macOS ZIP

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -383,17 +383,26 @@ jobs:
           install_name_tool -change /opt/homebrew/opt/lmdb/lib/liblmdb.dylib @executable_path/../Frameworks/liblmdb.dylib Rune.app/Contents/MacOS/Rune
         working-directory: build/macos/Build/Products/Release
 
+      - name: Rename DMG
+        run: |
+          mv temp_macos/*.dmg "temp_macos/Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS.dmg"
+
+      - name: Rename ZIP
+        run: |
+          mv temp_macos/*.zip "temp_macos/Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS.zip"
+
       - name: Upload artifact macOS DMG
         uses: actions/upload-artifact@v4
         with:
-          path: "temp_macos/*.dmg"
-          name: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS
+          path: temp_macos/temp_macos/Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS.dmg
+          name: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS.dmg
 
       - name: Upload artifact macOS ZIP
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
-          path: "temp_macos/*.zip"
-          name: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS-zip
+          path: temp_macos/Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS.zip
+          name: Rune-${{ github.ref_name }}${{ github.event_name == 'workflow_dispatch' && format('-{0}', steps.short-sha.outputs.sha) || '' }}-macOS.zip
 
       - name: Clean up
         if: ${{ always() }}
@@ -404,16 +413,6 @@ jobs:
             security delete-keychain $RUNNER_TEMP/rune-signing.keychain-db
           fi
           rm -f .env
-        
-      - name: Rename DMG
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          mv temp_macos/*.dmg "temp_macos/Rune-${{ github.ref_name }}-macOS.dmg"
-
-      - name: Rename ZIP
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          mv temp_macos/*.zip "temp_macos/Rune-${{ github.ref_name }}-macOS.zip"
 
       - name: Release DMG
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
### Context
Recent changes introduced an artifact filename conflict for MacOS ZIP uploads due to incorrect filename handling. Additionally, the current workflow for MacOS DMG files involves nesting them inside a ZIP file, which adds unnecessary complexity and nesting.

### Changes Made
1. **Fix MacOS ZIP Upload Filename Conflict:**
   - Corrected the artifact filename for MacOS zip uploads to avoid conflicts.
   - Ensured unique and consistent naming conventions for MacOS artifacts.

2. **Remove Nested ZIP Structure for MacOS DMG:**
   - Adjusted the workflow to upload MacOS DMG files directly instead of nesting them inside a ZIP.
   - Simplified the artifact structure for easier access and usability.

Resolve CI problem in https://github.com/Losses/rune/actions/runs/12132874788

---

### Impact
- Users will benefit from consistent and conflict-free artifact uploads.
- The simplified artifact structure enhances usability and access to the MacOS DMG files.

## Summary by Sourcery

Fix filename conflict for MacOS ZIP uploads and simplify the artifact structure by removing the nested ZIP for DMG files in the CI workflow.

Bug Fixes:
- Resolve filename conflict for MacOS ZIP uploads by correcting artifact naming conventions.

Enhancements:
- Remove nested ZIP structure for MacOS DMG files to simplify artifact structure and improve usability.

CI:
- Update CI workflow to directly upload MacOS DMG files without nesting them inside a ZIP.