### PR TITLE
fix(macOS): Ablum title offset

### DIFF
--- a/lib/screens/query_tracks/query_tracks.dart
+++ b/lib/screens/query_tracks/query_tracks.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:provider/provider.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 
@@ -45,9 +47,12 @@ class _QueryTracksPageState extends State<QueryTracksPage> {
               children: [
                 if (!isMini)
                   Padding(
-                    padding: const EdgeInsets.fromLTRB(20, 54, 24, 12),
+                    padding: Platform.isMacOS
+                        ? const EdgeInsets.fromLTRB(24, 54, 24, 12)
+                        : const EdgeInsets.fromLTRB(20, 54, 24, 12),
                     child: Transform.scale(
                       scale: 1.2,
+                      alignment: Alignment.centerLeft,
                       child: Text(
                         widget.title ?? 'Tracks',
                         style: TextStyle(color: theme.inactiveColor),


### PR DESCRIPTION
![CleanShot 2024-12-03 at 21 49 49@2x](https://github.com/user-attachments/assets/ac1aa1d9-e245-49c2-91de-aca10e4815dc)

The parent title and child title both have a left offset of 24px, but due to font and typography reasons, they are not perfectly aligned visually.

IDK how to fix it, @Losses Could you provide some help?

## Summary by Sourcery

Bug Fixes:
- Fix the alignment of album titles on macOS by adjusting the left padding to 24px.