### PR TITLE
fix(macOS): Traffic lights reset after showing file seletor

### DIFF
--- a/lib/screens/home/widgets/welcome.dart
+++ b/lib/screens/home/widgets/welcome.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:provider/provider.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:file_selector/file_selector.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../../../utils/ax_shadow.dart';
@@ -11,6 +10,7 @@ import '../../../utils/dialogs/failed_to_initialize_library.dart';
 import '../../../providers/library_path.dart';
 import '../../../providers/library_manager.dart';
 import '../../../providers/responsive_providers.dart';
+import '../../../utils/get_dir_path.dart';
 import '../../../utils/l10n.dart';
 
 class WelcomePage extends StatelessWidget {
@@ -79,7 +79,7 @@ class WelcomePage extends StatelessWidget {
                               // on Android, check for permission
                               if (!await requestAndroidPermission()) return;
 
-                              final path = await getDirectoryPath();
+                              final path = await getDirPath();
 
                               if (path == null) return;
                               if (!context.mounted) return;

--- a/lib/screens/settings_library/widgets/add_library_setting_button.dart
+++ b/lib/screens/settings_library/widgets/add_library_setting_button.dart
@@ -1,9 +1,9 @@
 import 'package:provider/provider.dart';
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:file_selector/file_selector.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../../utils/api/close_library.dart';
+import '../../../utils/get_dir_path.dart';
 import '../../../utils/router/navigation.dart';
 import '../../../utils/dialogs/failed_to_initialize_library.dart';
 import '../../../providers/library_manager.dart';
@@ -33,7 +33,7 @@ class AddLibrarySettingButton extends StatelessWidget {
       title: S.of(context).addLibrary,
       subtitle: S.of(context).addLibrarySubtitle,
       onPressed: () async {
-        final path = await getDirectoryPath();
+        final path = await getDirPath();
 
         if (path == null) return;
         if (!context.mounted) return;

--- a/lib/utils/get_dir_path.dart
+++ b/lib/utils/get_dir_path.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:file_selector/file_selector.dart';
+
+import 'macos_window_control_button_manager.dart';
+
+// TODO(hexagram): This is a temporary solution, not the best way to handle this callback.
+// Once BitsdojoWindow is forked and rewritten, using NSWindowDelagate to listen for windowDidEndSheet and windowWillBeginSheet will be a more general andbetter solution to handle this.
+Future<String?> getDirPath() async {
+  final path = await getDirectoryPath();
+  if (Platform.isMacOS) {
+    MacOSWindowControlButtonManager.setVertical();
+  }
+  return path;
+}


### PR DESCRIPTION
## Summary by Sourcery

Fix the macOS traffic lights reset issue by refactoring the directory path selection logic and introducing a new utility function to manage macOS-specific behavior.

Bug Fixes:
- Fix the issue where traffic lights reset after showing the file selector on macOS by adjusting the window control button manager.

Enhancements:
- Refactor the directory path selection logic by introducing a new utility function 'getDirPath' to handle macOS-specific behavior.