### PR TITLE
fix(macOS): Add 2px to album offset for visual alignment

### DIFF
--- a/lib/screens/query_tracks/query_tracks.dart
+++ b/lib/screens/query_tracks/query_tracks.dart
@@ -48,7 +48,9 @@ class _QueryTracksPageState extends State<QueryTracksPage> {
                 if (!isMini)
                   Padding(
                     padding: Platform.isMacOS
-                        ? const EdgeInsets.fromLTRB(24, 54, 24, 12)
+                        // The left offset on macOS should be the same as the naviagtion_bar's parent title left offset
+                        // But due to font and typography reasons(#166), we need to add 2px to visually align them.
+                        ? const EdgeInsets.fromLTRB(26, 54, 24, 12)
                         : const EdgeInsets.fromLTRB(20, 54, 24, 12),
                     child: Transform.scale(
                       scale: 1.2,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Adjust the left padding on macOS by adding 2px for better visual alignment of album offset.