### PR TITLE
fix(macos): Remove unused network.server entitlement.

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,7 +12,5 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -2,12 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>keychain-access-groups</key>
-	<array/>
-	<key>com.apple.developer.team-identifier</key>
-	<string>LG57TUQ726</string>
 	<key>com.apple.application-identifier</key>
 	<string>LG57TUQ726.ci.not.rune</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>LG57TUQ726</string>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
@@ -18,7 +16,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove unused network.server entitlement from macOS entitlements files.