### PR TITLE
feat: Add assets to Linux release package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,12 @@ jobs:
         no_output_timeout: 30m
         command: flutter build linux --release --verbose
     - run:
+        name: Add assets
+        command: |
+          mkdir -p build/linux/arm64/release/bundle/assets
+          cp -r assets/icons/Papirus build/linux/arm64/release/bundle/assets/icons
+          cp assets/source/linux/* build/linux/arm64/release/bundle/assets
+    - run:
         name: Package artifact
         command: |
           cd build/linux/arm64/release/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,6 +193,12 @@ jobs:
         with:
           length: 7
 
+      - name: Add assets
+        run: |
+          mkdir -p build/linux/x64/release/bundle/assets
+          cp -r assets/icons/Papirus build/linux/x64/release/bundle/assets/icons
+          cp assets/source/linux/* build/linux/x64/release/bundle/assets
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/assets/source/linux/rune.desktop
+++ b/assets/source/linux/rune.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Rune
+Comment=Experience timeless melodies with a music player that blends classic design with modern technology
+Categories=AudioVideo;Audio;Player;Music;
+Icon=rune
+Exec=rune
+Terminal=false

--- a/assets/source/linux/rune.metainfo.xml
+++ b/assets/source/linux/rune.metainfo.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>ci.not.Rune</id>
+  
+  <name>Rune</name>
+  <summary>Experience timeless melodies with a music player that blends classic design with modern technology</summary>
+  
+  <metadata_license>CC-BY-SA-4.0</metadata_license>
+  <project_license>MPL-2.0</project_license>
+  
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </supports>
+
+  <developer_name>losses</developer_name>
+  
+  <description>
+    <p>
+      Experience timeless melodies with a music player that blends classic design with modern technology
+    </p>
+  </description>
+
+  <content_rating type="oars-1.1"/>
+  
+  <launchable type="desktop-id">ci.not.Rune.desktop</launchable>
+  
+  <screenshots>
+    <screenshot type="default">
+      <image type="source" width="2560" height="1514">https://raw.githubusercontent.com/Losses/rune/refs/heads/master/assets/source/steam/screenshot/00.png</image>
+      <caption>Main window</caption>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+  </releases>
+</component>


### PR DESCRIPTION
Add basic assets to Linux release package to fulfill part of Flathub's submission requirements (https://github.com/flathub/flathub/pull/5907)

## Summary by Sourcery

Add assets to the Linux release package to comply with Flathub's submission requirements, and update CI workflows to incorporate these assets into the build process.

New Features:
- Add basic assets to the Linux release package, including icons and metadata files, to meet Flathub's submission requirements.

CI:
- Update CircleCI and GitHub Actions workflows to include steps for adding assets to the Linux build.