### PR TITLE
feat(macOS): Hide traffic lights in band and dock sizes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,7 @@
 set dotenv-load
 
 lint:
+  cargo fmt -- $(find native/hub/src/messages -name "*.rs")
   cargo fmt -- --check
   cargo clippy -- -D warnings
   flutter analyze .

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -210,7 +210,7 @@ void main(List<String> arguments) async {
 
   doWhenWindowReady(() {
     if (Platform.isMacOS) {
-      MacOSWindowControlButtonManager.setVertical();
+      MacOSWindowControlButtonManager.shared.setVertical();
     }
 
     appWindow.size = windowSize;

--- a/lib/utils/macos_window_control_button_manager.dart
+++ b/lib/utils/macos_window_control_button_manager.dart
@@ -1,9 +1,21 @@
 import 'package:flutter/services.dart';
 
 class MacOSWindowControlButtonManager {
-  static const platform = MethodChannel('not.ci.rune/window_control_button');
+  static var shared = MacOSWindowControlButtonManager._();
 
-  static Future<void> setVertical() async {
+  MacOSWindowControlButtonManager._();
+
+  var platform = MethodChannel('not.ci.rune/window_control_button');
+
+  Future<void> setVertical() async {
     await platform.invokeMethod('set_vertical');
+  }
+
+  Future<void> setHide() async {
+    await platform.invokeMethod('set_hide');
+  }
+
+  Future<void> setShow() async {
+    await platform.invokeMethod('set_show');
   }
 }

--- a/lib/widgets/title_bar/window_frame_for_macos.dart
+++ b/lib/widgets/title_bar/window_frame_for_macos.dart
@@ -72,6 +72,13 @@ class _WindowFrameForMacOSState extends State<WindowFrameForMacOS> {
           ],
           builder: (context, activeBreakpoint) {
             if (activeBreakpoint == DeviceType.band ||
+                activeBreakpoint == DeviceType.dock) {
+              MacOSWindowControlButtonManager.shared.setHide();
+            } else {
+              MacOSWindowControlButtonManager.shared.setShow();
+            }
+
+            if (activeBreakpoint == DeviceType.band ||
                 activeBreakpoint == DeviceType.dock ||
                 path == '/' ||
                 path == '/scanning') {

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -21,6 +21,10 @@ class MainFlutterWindow: BitsdojoWindow {
       switch call.method {
       case "set_vertical":
         WindowButtonPositioner.shared.setVertical()
+      case "set_hide":
+        WindowButtonPositioner.shared.setHide()
+      case "set_show":
+        WindowButtonPositioner.shared.setShow()
       default:
         result(FlutterMethodNotImplemented)
       }
@@ -85,6 +89,18 @@ class WindowButtonPositioner {
 
   init(mainFlutterWindow: NSWindow) {
     self.mainFlutterWindow = mainFlutterWindow
+  }
+
+  func setHide() {
+    mainFlutterWindow?.standardWindowButton(.closeButton)?.isHidden = true
+    mainFlutterWindow?.standardWindowButton(.miniaturizeButton)?.isHidden = true
+    mainFlutterWindow?.standardWindowButton(.zoomButton)?.isHidden = true
+  }
+
+  func setShow() {
+    mainFlutterWindow?.standardWindowButton(.closeButton)?.isHidden = false
+    mainFlutterWindow?.standardWindowButton(.miniaturizeButton)?.isHidden = false
+    mainFlutterWindow?.standardWindowButton(.zoomButton)?.isHidden = false
   }
 
   func setVertical() {

--- a/native/hub/src/license.rs
+++ b/native/hub/src/license.rs
@@ -42,15 +42,13 @@ pub async fn check_store_license() -> Result<Option<(String, bool, bool)>> {
 pub async fn check_store_license() -> Result<Option<(String, bool, bool)>, &'static str> {
     use crate::apple_bridge::apple_bridge::bundle_id;
     let bundle_id = bundle_id();
-    let mut is_active = false;
-    let mut is_trial = false;
 
     if bundle_id == "ci.not.rune.appstore" {
-        is_active = true;
-        is_trial = false;
+        let is_active = true;
+        let is_trial = false;
         Ok(Some((bundle_id, is_active, is_trial)))
     } else {
-        return Ok(None)
+        Ok(None)
     }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Add functionality to hide macOS window control buttons in band and dock sizes, and refactor the MacOSWindowControlButtonManager to use a shared instance for managing button visibility and positioning.

New Features:
- Introduce functionality to hide and show macOS window control buttons based on device type.

Enhancements:
- Refactor MacOSWindowControlButtonManager to use a shared instance for managing window control buttons.