### PR TITLE
fix: Make Rune work again on Android

### DIFF
--- a/lib/widgets/title_bar/window_frame.dart
+++ b/lib/widgets/title_bar/window_frame.dart
@@ -14,6 +14,8 @@ class WindowFrame extends StatelessWidget {
   Widget build(BuildContext context) {
     if (Platform.isMacOS) {
       return WindowFrameForMacOS(child, customRouteName: customRouteName);
+    } else if (Platform.isAndroid) {
+      return child;
     } else {
       return WindowFrameForWindows(child);
     }


### PR DESCRIPTION
## Summary by Sourcery

Fix Rune application to work on Android by bypassing desktop-specific code and refactor to conditionally execute desktop-specific functionality only on desktop platforms.

Bug Fixes:
- Fix Rune application to work on Android by bypassing desktop-specific code.

Enhancements:
- Refactor code to conditionally execute desktop-specific functionality only when running on desktop platforms.