### PR TITLE
fix: Add file extension to AppStream launchable field

### DIFF
--- a/assets/source/linux/rune.metainfo.xml
+++ b/assets/source/linux/rune.metainfo.xml
@@ -26,7 +26,7 @@
 
   <content_rating type="oars-1.1" />
 
-  <launchable type="desktop-id">rune</launchable>
+  <launchable type="desktop-id">rune.desktop</launchable>
 
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
When it means desktop-id, it actually means desktop-file.

## Summary by Sourcery

Bug Fixes:
- Correct the AppStream launchable field by adding the file extension to the desktop-id.