### PR TITLE
fix: Remove redundant path from arm release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,9 @@ jobs:
     - run:
         name: Package artifact
         command: |
-          cd build/linux/arm64/release/
+          cd build/linux/arm64/release/bundle/
           TAG=${CIRCLE_TAG}
-          zip -r Rune-${TAG}-linux-aarch64.zip bundle/
+          zip -r ../Rune-${TAG}-linux-aarch64.zip .
     - run:
         name: Upload to GitHub Release
         command: |


### PR DESCRIPTION
Sync arm release to have the same behavior x86 release currently has, with no `bundle` root directory in it's release package.

## Summary by Sourcery

Align ARM release packaging with x86 by removing the redundant 'bundle' directory from the release package and updating the CI configuration accordingly.

Bug Fixes:
- Remove redundant 'bundle' directory from ARM release package to align with x86 release behavior.

CI:
- Update CI configuration to change the packaging path for ARM release.