### PR TITLE
fix: Update makeLatest condition to exclude alpha and beta branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           allowUpdates: true
           replacesArtifacts: false
           omitBodyDuringUpdate: true
-          makeLatest: true
+          makeLatest: ${{ !(contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')) }}
 
   build-windows-msix:
     runs-on: windows-latest
@@ -142,7 +142,7 @@ jobs:
           allowUpdates: true
           replacesArtifacts: false
           omitBodyDuringUpdate: true
-          makeLatest: true
+          makeLatest: ${{ !(contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')) }}
 
   build-linux:
     runs-on: ubuntu-latest
@@ -221,7 +221,7 @@ jobs:
           allowUpdates: true
           replacesArtifacts: false
           omitBodyDuringUpdate: true
-          makeLatest: true
+          makeLatest: ${{ !(contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')) }}
 
   build-steam-sniper:
     runs-on: ubuntu-latest
@@ -315,7 +315,7 @@ jobs:
           allowUpdates: true
           replacesArtifacts: false
           omitBodyDuringUpdate: true
-          makeLatest: true
+          makeLatest: ${{ !(contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')) }}
 
   build-macos:
     runs-on: macos-latest
@@ -427,7 +427,7 @@ jobs:
           allowUpdates: true
           replacesArtifacts: false
           omitBodyDuringUpdate: true
-          makeLatest: true
+          makeLatest: ${{ !(contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')) }}
 
       - name: Release ZIP
         uses: ncipollo/release-action@v1
@@ -437,7 +437,7 @@ jobs:
           allowUpdates: true
           replacesArtifacts: false
           omitBodyDuringUpdate: true
-          makeLatest: true
+          makeLatest: ${{ !(contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')) }}
 
       - name: Clean up
         if: ${{ always() }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the build workflow to prevent marking builds from the "alpha" and "beta" branches as the "latest" build.