### PR TITLE
feat(iOS): Support system media control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4783,9 +4783,9 @@ dependencies = [
 [[package]]
 name = "souvlaki"
 version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4544ba17df4ac03d6503ae8abba19adad3ae89203a425945dc4c12d7790bfa"
+source = "git+https://github.com/XMLHexagram/souvlaki?branch=master#e60e9b9a6a2774306718a0c561609083f1acc617"
 dependencies = [
+ "base64 0.22.1",
  "block",
  "cocoa",
  "core-graphics",

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,7 +9,7 @@ func initAudioSession() {
       try audio_session.setActive(true);
   } catch {
       // This is a fatal error because the audio session is required for the app to work
-      fatalError(error);
+      fatalError("\(error)");
   }
 }
 

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -43,8 +43,8 @@ windows = { version = "0.44.0", features = [
 once_cell = "1.20.2"
 simple_channel = { path = "../simple-channel" }
 
-[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
-souvlaki = "0.7.3"
+[target.'cfg(not(any(target_os = "android")))'.dependencies]
+souvlaki = { git = "https://github.com/XMLHexagram/souvlaki", branch = "master" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-context = "0.1.1"

--- a/playback/src/controller.rs
+++ b/playback/src/controller.rs
@@ -13,9 +13,10 @@ use log::{debug, info};
 use once_cell::sync::OnceCell;
 use tokio::sync::Mutex;
 
-#[cfg(any(target_os = "android", target_os = "ios"))]
+#[cfg(target_os = "android")]
 use crate::dummy_souvlaki::{MediaControlEvent, MediaControls, PlatformConfig, SeekDirection};
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
+
+#[cfg(not(target_os = "android"))]
 use souvlaki::{MediaControlEvent, MediaControls, PlatformConfig, SeekDirection};
 
 use simple_channel::{SimpleChannel, SimpleReceiver, SimpleSender};
@@ -51,7 +52,7 @@ pub struct MediaControlManager {
 
 impl MediaControlManager {
     pub fn new() -> Result<Self> {
-        #[cfg(not(any(target_os = "windows", target_os = "android", target_os = "ios")))]
+        #[cfg(not(any(target_os = "windows")))]
         let hwnd = None;
 
         #[cfg(target_os = "windows")]
@@ -61,13 +62,9 @@ impl MediaControlManager {
             (Some(handle), dummy_window)
         };
 
-        // #[cfg(target_os = "android")]
-        // let hwnd = ();
-
         let config = PlatformConfig {
             dbus_name: "rune_player",
             display_name: "Rune",
-            #[cfg(not(any(target_os = "android", target_os = "ios")))]
             hwnd,
         };
 

--- a/playback/src/dummy_souvlaki.rs
+++ b/playback/src/dummy_souvlaki.rs
@@ -43,6 +43,7 @@ pub enum SeekDirection {
 pub struct PlatformConfig {
     pub dbus_name: &'static str,
     pub display_name: &'static str,
+    pub hwnd: Option<()>,
 }
 
 /// A platform-specific error.

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -10,14 +10,14 @@ pub mod player;
 pub mod sfx_player;
 pub mod strategies;
 
-#[cfg(any(target_os = "android", target_os = "ios"))]
+#[cfg(target_os = "android")]
 mod dummy_souvlaki;
 
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-pub use souvlaki::{MediaMetadata, MediaPlayback, MediaPosition};
-
-#[cfg(any(target_os = "android", target_os = "ios"))]
+#[cfg(target_os = "android")]
 pub use dummy_souvlaki::{MediaMetadata, MediaPlayback, MediaPosition};
+
+#[cfg(not(target_os = "android"))]
+pub use souvlaki::{MediaMetadata, MediaPlayback, MediaPosition};
 
 pub use internal::{PlayerCommand, PlayerEvent};
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for system media controls on iOS.

New Features:
- Enable system media controls on iOS.

Tests:
- Update tests to reflect changes.