### PR TITLE
fix: Build issues caused by importing swift-rs

### DIFF
--- a/native/hub/Cargo.toml
+++ b/native/hub/Cargo.toml
@@ -37,7 +37,6 @@ tracing-appender = "0.2.3"
 chrono = "0.4.38"
 windows = { version = "0.58.0", features = ["Services", "Services_Store" ] }
 sha2 = "0.10.8"
-swift-rs = "1.0.7"
 
 [build-dependencies]
 anyhow = { version = "1.0.89", features = ["backtrace"] }
@@ -47,8 +46,6 @@ vergen-git2 = { version = "1.0.1", features = [
     "rustc",
     "si",
 ] }
-swift-rs = { version = "1.0.7", features = ["build"] }
-
 
 # Uncomment below to target the web.
 # tokio_with_wasm = { version = "0.6.0", features = ["sync", "rt"] }
@@ -57,3 +54,9 @@ swift-rs = { version = "1.0.7", features = ["build"] }
 # Android dependencies
 [target.'cfg(target_os = "android")'.dependencies]
 tracing-logcat = "0.1.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+swift-rs = "1.0.7"
+
+[target.'cfg(target_os = "macos")'.build-dependencies]
+swift-rs = { version = "1.0.7", features = ["build"] }

--- a/native/hub/build.rs
+++ b/native/hub/build.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::env;
+#[cfg(target_os = "macos")]
 use swift_rs::SwiftLinker;
 use vergen_git2::{BuildBuilder, Emitter, Git2Builder, RustcBuilder};
 
@@ -23,6 +24,7 @@ fn main() -> Result<()> {
     let target = std::env::var("TARGET").unwrap();
 
     if target.contains("darwin") {
+        #[cfg(target_os = "macos")]
         SwiftLinker::new("10.13")
             .with_ios("12")
             .with_package("apple-bridge-library", "./apple-bridge-library/")


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Remove `swift-rs` from general dependencies and add it as a dependency for macOS targets.