### PR TITLE
RE: fix(iOS): Color mode switch error

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,7 +96,8 @@ void main(List<String> arguments) async {
     final isWindows10 = windowsInfo.productName.startsWith('Windows 10');
     isWindows11 = windowsInfo.productName.startsWith('Windows 11');
 
-    if (isWindows10 && appTheme.windowEffect == WindowEffect.mica) {
+    if ((isWindows10 && appTheme.windowEffect == WindowEffect.mica) ||
+        Platform.isIOS) {
       appTheme.windowEffect = WindowEffect.solid;
     }
   } catch (e) {
@@ -390,7 +391,7 @@ class _RuneState extends State<Rune> {
             final theme = FluentTheme.of(context);
 
             Widget content = Container(
-              color: (appTheme.windowEffect == WindowEffect.solid || Platform.isIOS)
+              color: appTheme.windowEffect == WindowEffect.solid
                   ? theme.micaBackgroundColor
                   : Colors.transparent,
               child: Directionality(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -390,7 +390,7 @@ class _RuneState extends State<Rune> {
             final theme = FluentTheme.of(context);
 
             Widget content = Container(
-              color: appTheme.windowEffect == WindowEffect.solid
+              color: (appTheme.windowEffect == WindowEffect.solid || Platform.isIOS)
                   ? theme.micaBackgroundColor
                   : Colors.transparent,
               child: Directionality(


### PR DESCRIPTION
Previous https://github.com/Losses/rune/pull/223

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where the color mode switch caused an error on iOS and Windows 10 when mica was selected.