### PR TITLE
RE: fix(iOS): Support secure bookmarks

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -718,11 +718,12 @@ packages:
   macos_secure_bookmarks:
     dependency: "direct main"
     description:
-      name: macos_secure_bookmarks
-      sha256: c3163875f8fd530a1654a7cf8aa426e6e208d28bf05724a1d4960e4b7d2ca1c6
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.1"
+      path: "."
+      ref: master
+      resolved-ref: c07abbf7c186c543de09a9c7df8577bbf5e27748
+      url: "https://github.com/XMLHexagram/macos_secure_bookmarks.git"
+    source: git
+    version: "0.2.0"
   macos_window_utils:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -719,7 +719,7 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: master
+      ref: c07abbf7c186c543de09a9c7df8577bbf5e27748
       resolved-ref: c07abbf7c186c543de09a9c7df8577bbf5e27748
       url: "https://github.com/XMLHexagram/macos_secure_bookmarks.git"
     source: git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,7 +69,7 @@ dependencies:
   macos_secure_bookmarks:
     git:
       url: https://github.com/XMLHexagram/macos_secure_bookmarks.git
-      ref: master
+      ref: c07abbf7c186c543de09a9c7df8577bbf5e27748
   permission_handler: ^11.3.1
   animated_flip_counter: ^0.3.4
   intl: ^0.19.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,7 +66,10 @@ dependencies:
   very_good_infinite_list: ^0.9.0
   flutter_fullscreen: ^1.0.1
   device_info_plus: ^11.1.1
-  macos_secure_bookmarks: ^0.2.1
+  macos_secure_bookmarks:
+    git:
+      url: https://github.com/XMLHexagram/macos_secure_bookmarks.git
+      ref: master
   permission_handler: ^11.3.1
   animated_flip_counter: ^0.3.4
   intl: ^0.19.0


### PR DESCRIPTION
Previous #221

## Summary by Sourcery

Enhancements:
- Pin macos_secure_bookmarks to commit c07abbf7c186c543de09a9c7df8577bbf5e27748.