### PR TITLE
fix: Make system_tray actually use installed icons on Linux Flatpak

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -170,10 +170,12 @@ void main(List<String> arguments) async {
   );
 
   if (isDesktop) {
+    final icon = TrayManager.getTrayIcon();
     await systemTray.initSystemTray(
       title: Platform.isMacOS ? null : 'Rune',
-      iconPath: TrayManager.getTrayIconPath(),
+      iconPath: icon.path,
       isTemplate: true,
+      isInstalled: icon.isInstalled,
     );
 
     final Menu menu = Menu();

--- a/lib/utils/tray_manager.dart
+++ b/lib/utils/tray_manager.dart
@@ -34,7 +34,7 @@ class TrayManager {
       return 'assets/tray_icon_$brightness.ico';
     }
 
-    if (Platform.isLinux && bool.hasEnvironment('FLATPAK_ID')) {
+    if (Platform.isLinux && Platform.environment.containsKey('FLATPAK_ID')) {
       return 'ci.not.Rune-tray-$brightness';
     }
 

--- a/lib/utils/tray_manager.dart
+++ b/lib/utils/tray_manager.dart
@@ -18,10 +18,17 @@ import 'l10n.dart';
 
 final SystemTray systemTray = SystemTray();
 
+class TrayIcon {
+  final String path;
+  final bool isInstalled;
+
+  TrayIcon(this.path, this.isInstalled);
+}
+
 class TrayManager {
-  static String getTrayIconPath() {
+  static TrayIcon getTrayIcon() {
     if (Platform.isMacOS) {
-      return 'assets/mac-tray.svg';
+      return TrayIcon('assets/mac-tray.svg', false);
     }
 
     final brightness =
@@ -31,14 +38,14 @@ class TrayManager {
             : Brightness.light.name;
 
     if (Platform.isWindows) {
-      return 'assets/tray_icon_$brightness.ico';
+      return TrayIcon('assets/tray_icon_$brightness.ico', false);
     }
 
     if (Platform.isLinux && Platform.environment.containsKey('FLATPAK_ID')) {
-      return 'ci.not.Rune-tray-$brightness';
+      return TrayIcon('ci.not.Rune-tray-$brightness', true);
     }
 
-    return 'assets/linux-tray-$brightness.svg';
+    return TrayIcon('assets/linux-tray-$brightness.svg', false);
   }
 
   bool? _cachedPlaying;
@@ -106,8 +113,8 @@ class TrayManager {
   }
 
   Future<void> updateTrayIcon() async {
-    final iconPath = getTrayIconPath();
-    await systemTray.setImage(iconPath, isTemplate: true);
+    final icon = getTrayIcon();
+    await systemTray.setImage(icon.path, isTemplate: true, isInstalled: icon.isInstalled);
   }
 
   static void registerEventHandlers() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1190,8 +1190,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: e0fd539785d2f656a8efd76376c6f2225848b9be
-      resolved-ref: e0fd539785d2f656a8efd76376c6f2225848b9be
+      ref: ddbf360835b1db404fbd52b07b250e0e2c950266
+      resolved-ref: ddbf360835b1db404fbd52b07b250e0e2c950266
       url: "https://github.com/Losses/system_tray.git"
     source: git
     version: "2.0.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,7 +80,7 @@ dependencies:
   system_tray:
     git:
       url: https://github.com/Losses/system_tray.git
-      ref: e0fd539785d2f656a8efd76376c6f2225848b9be
+      ref: ddbf360835b1db404fbd52b07b250e0e2c950266
   scrollable_positioned_list:
     git:
       url: https://github.com/Losses/scrollable_positioned_list.git


### PR DESCRIPTION
Note: this pull request is depended on https://github.com/Losses/system_tray/pull/1

The `system_tray` package currently will rewrite `iconPath` to it's absolute path, this pull request series allow installed icons to able to be used.

## Summary by Sourcery

Update the system tray icon handling to use installed icons when available on Linux Flatpak.