### PR TITLE
fix(macos): add relevant entitlements so networking would work

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,6 +12,8 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -16,6 +16,10 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 	<key>keychain-access-groups</key>
 	<array/>
 </dict>


### PR DESCRIPTION
## Summary by Sourcery

Adds the required entitlements to the macOS build configuration to enable networking functionality.

Bug Fixes:
- Fixes an issue on macOS where networking functionality was broken due to missing entitlements.

Build:
- Adds the necessary entitlements to the DebugProfile.entitlements and Release.entitlements files to enable networking on macOS.