### PR TITLE
fix(ci): add ExportOptions for iOS

### DIFF
--- a/ios/ExportOptions-AppStore.plist
+++ b/ios/ExportOptions-AppStore.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>ci.not.rune.appstore</key>
+		<string>Rune iOS App Store</string>
+	</dict>
+	<key>signingCertificate</key>
+	<string>iPhone Distribution</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>teamID</key>
+	<string>LG57TUQ726</string>
+</dict>
+</plist>

--- a/scripts/apple/ios/2_build_for_appstore.sh
+++ b/scripts/apple/ios/2_build_for_appstore.sh
@@ -16,4 +16,9 @@ rinf message
 cd ios
 pod update
 cd ..
-flutter build ipa --build-number $RUNE_APPSTORE_BUILD_NUMBER --build-name $RUNE_APPSTORE_BUILD_VERSION --release
+
+flutter build ipa \
+  --build-number $RUNE_APPSTORE_BUILD_NUMBER \
+  --build-name $RUNE_APPSTORE_BUILD_VERSION \
+  --export-options-plist ios/ExportOptions-AppStore.plist \
+  --release


### PR DESCRIPTION
## Summary by Sourcery

Configures the iOS build process for the App Store by adding an export options plist file and referencing it in the flutter build command.

Build:
- Adds an export options plist file for the App Store build.
- Updates the flutter build command to include the export options plist file.