### PR TITLE
ci: specify Xcode 16.4 on macOS 15.5 for macOS / iOS builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install the Rust dependencies
-        run:  cargo install rinf_cli
+        run: cargo install rinf_cli
 
       - name: Flutter pub get
         run: flutter pub get
@@ -283,7 +283,7 @@ jobs:
           makeLatest: ${{ !(contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')) }}
 
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-15
     permissions:
       contents: write
     steps:
@@ -409,7 +409,7 @@ jobs:
           rm -f .env
 
   build-and-release-mac-app-store:
-    runs-on: macos-latest
+    runs-on: macos-15
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout repository
@@ -505,7 +505,7 @@ jobs:
           rm -f .env
           rm -f $RUNNER_TEMP/*.p8
   build-and-release-ios-app-store:
-    runs-on: macos-latest
+    runs-on: macos-15
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout repository

--- a/scripts/apple/ios/1_ci_setup_deps.sh
+++ b/scripts/apple/ios/1_ci_setup_deps.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+sudo xcode-select -s /Applications/Xcode_16.4.app
+
 cd "$(dirname "$0")"
 cd ../../..
 

--- a/scripts/macos_1_ci_install.sh
+++ b/scripts/macos_1_ci_install.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+sudo xcode-select -s /Applications/Xcode_16.4.app
+
 cd "$(dirname "$0")"
 cd ..
 


### PR DESCRIPTION
## Summary by Sourcery

Pin macOS runners to macos-15 and configure Xcode 16.4 in CI for Mac and iOS build jobs

CI:
- Change runs-on from macos-latest to macos-15 for macOS and iOS build-and-release jobs
- Add sudo xcode-select -s /Applications/Xcode_16.4.app to macOS and iOS CI setup scripts