### PR TITLE
ci: Downgrade build runner to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
           makeLatest: ${{ !(contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')) }}
 
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
This might solve the issue of the GLIBC version being too high.

fixes #276 


----
Test build: https://github.com/abc1763613206/rune/actions/runs/17393055021