### PR TITLE
feat: add a scroll bar to the tracks list

### DIFF
--- a/database/src/actions/file.rs
+++ b/database/src/actions/file.rs
@@ -196,3 +196,7 @@ pub async fn get_duration_by_file_id(
         ))
     }
 }
+
+pub async fn get_media_files_count(db: &DatabaseConnection) -> Result<u64, sea_orm::DbErr> {
+    media_files::Entity::find().count(db).await
+}

--- a/lib/screens/query_tracks/query_tracks_list.dart
+++ b/lib/screens/query_tracks/query_tracks_list.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+import 'package:flutter/scheduler.dart';
 
 import '../../utils/query_list.dart';
 import '../../utils/api/query_mix_tracks.dart';
@@ -35,59 +35,116 @@ class QueryTrackListView extends StatefulWidget {
 class QueryTrackListViewState extends State<QueryTrackListView> {
   static const _pageSize = 20;
 
-  final PagingController<int, InternalMediaFile> _pagingController =
-      PagingController(firstPageKey: 0);
+  int _totalCount = 0;
+  final Map<int, InternalMediaFile> _loadedItems = {};
+  final Set<int> _loadingIndices = {};
+  bool _isInitialized = false;
+  bool _reachedEnd = false;
 
   @override
   void initState() {
-    _pagingController.addPageRequestListener((cursor) async {
-      await _fetchPage(cursor);
+    super.initState();
+    _initializeData();
+  }
+
+  Future<void> _initializeData() async {
+    setState(() {
+      _isInitialized = true;
+    });
+    // Pre-load first page
+    _loadPage(0);
+  }
+
+  Future<void> _loadPage(int cursor) async {
+    if (_loadingIndices.contains(cursor) || _reachedEnd) return;
+
+    // Immediately mark as loading to prevent duplicate requests
+    _loadingIndices.add(cursor);
+
+    // Schedule setState for after the current build phase to update UI
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() {});
+    });
+
+    try {
+      final newItems = await queryMixTracks(widget.queries, cursor, _pageSize);
+
+      if (!mounted) return;
+
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        setState(() {
+          for (var i = 0; i < newItems.length; i++) {
+            _loadedItems[cursor + i] = newItems[i];
+          }
+          _loadingIndices.remove(cursor);
+
+          // Update total count
+          final newTotal = cursor + newItems.length;
+          if (newTotal > _totalCount) {
+            _totalCount = newTotal;
+          }
+
+          // Check if we've reached the end
+          if (newItems.length < _pageSize) {
+            _reachedEnd = true;
+            _totalCount = cursor + newItems.length;
+          }
+        });
+      });
 
       Timer(
         Duration(milliseconds: gridAnimationDelay),
         () => widget.layoutManager.playAnimations(),
       );
-    });
-    super.initState();
-  }
-
-  Future<void> _fetchPage(int cursor) async {
-    try {
-      final newItems = await queryMixTracks(
-        widget.queries,
-        cursor,
-        _pageSize,
-      );
-
+    } catch (error) {
       if (!mounted) return;
 
-      final isLastPage = newItems.length < _pageSize;
-      if (isLastPage) {
-        _pagingController.appendLastPage(newItems);
-      } else {
-        final nextCursor = cursor + newItems.length;
-        _pagingController.appendPage(newItems, nextCursor);
-      }
-    } catch (error) {
-      _pagingController.error = error;
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        setState(() {
+          _loadingIndices.remove(cursor);
+        });
+      });
     }
+  }
+
+  void _checkAndLoadItem(int index) {
+    if (_loadedItems.containsKey(index) ||
+        (index >= _totalCount && _reachedEnd))
+      return;
+    if (_loadingIndices.contains((index ~/ _pageSize) * _pageSize)) return;
+
+    final pageStart = (index ~/ _pageSize) * _pageSize;
+    _loadPage(pageStart);
+  }
+
+  InternalMediaFile? _getItem(int index) {
+    _checkAndLoadItem(index);
+    return _loadedItems[index];
   }
 
   @override
   Widget build(BuildContext context) {
+    if (!_isInitialized) {
+      return const Center(child: ProgressRing());
+    }
+
     return DeviceTypeBuilder(
       deviceType: const [
         DeviceType.band,
         DeviceType.belt,
         DeviceType.dock,
         DeviceType.zune,
-        DeviceType.tv
+        DeviceType.tv,
       ],
       builder: (context, activeBreakpoint) {
         if (activeBreakpoint == DeviceType.belt) {
           return BeltContainer(
             child: BandScreenTrackList(
-              pagingController: _pagingController,
+              totalCount: _totalCount,
+              getItem: _getItem,
               queries: widget.queries,
               mode: widget.mode,
               topPadding: widget.topPadding,
@@ -98,7 +155,8 @@ class QueryTrackListViewState extends State<QueryTrackListView> {
         if (activeBreakpoint == DeviceType.dock ||
             activeBreakpoint == DeviceType.band) {
           return BandScreenTrackList(
-            pagingController: _pagingController,
+            totalCount: _totalCount,
+            getItem: _getItem,
             queries: widget.queries,
             mode: widget.mode,
             topPadding: widget.topPadding,
@@ -107,7 +165,8 @@ class QueryTrackListViewState extends State<QueryTrackListView> {
 
         if (activeBreakpoint == DeviceType.zune) {
           return SmallScreenTrackList(
-            pagingController: _pagingController,
+            totalCount: _totalCount,
+            getItem: _getItem,
             queries: widget.queries,
             mode: widget.mode,
             topPadding: widget.topPadding,
@@ -115,7 +174,8 @@ class QueryTrackListViewState extends State<QueryTrackListView> {
         }
 
         return LargeScreenTrackList(
-          pagingController: _pagingController,
+          totalCount: _totalCount,
+          getItem: _getItem,
           queries: widget.queries,
           mode: widget.mode,
           topPadding: widget.topPadding,
@@ -126,7 +186,6 @@ class QueryTrackListViewState extends State<QueryTrackListView> {
 
   @override
   void dispose() {
-    _pagingController.dispose();
     super.dispose();
   }
 }

--- a/lib/utils/api/get_media_files_count.dart
+++ b/lib/utils/api/get_media_files_count.dart
@@ -1,0 +1,17 @@
+import '../../bindings/bindings.dart';
+
+Future<int> getMediaFilesCount() async {
+  final request = GetMediaFilesCountRequest();
+  request.sendSignalToRust();
+
+  try {
+    final rustSignal = await GetMediaFilesCountResponse.rustSignalStream.first
+        .timeout(const Duration(seconds: 5));
+    final response = rustSignal.message;
+
+    return response.count;
+  } catch (e) {
+    print('Error getting media files count: $e');
+    rethrow;
+  }
+}

--- a/lib/widgets/track_list/band_screen_track_list.dart
+++ b/lib/widgets/track_list/band_screen_track_list.dart
@@ -1,5 +1,4 @@
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 
 import '../../utils/query_list.dart';
 import '../../utils/format_time.dart';
@@ -25,14 +24,16 @@ import '../navigation_bar/page_content_frame.dart';
 import '../tile/cover_art.dart';
 
 class BandScreenTrackList extends StatelessWidget {
-  final PagingController<int, InternalMediaFile> pagingController;
+  final int totalCount;
+  final InternalMediaFile? Function(int) getItem;
   final QueryList queries;
   final int mode;
   final bool topPadding;
 
   const BandScreenTrackList({
     super.key,
-    required this.pagingController,
+    required this.totalCount,
+    required this.getItem,
     required this.queries,
     required this.mode,
     required this.topPadding,
@@ -47,7 +48,7 @@ class BandScreenTrackList extends StatelessWidget {
         DeviceType.band,
         DeviceType.belt,
         DeviceType.dock,
-        DeviceType.tv
+        DeviceType.tv,
       ],
       builder: (context, deviceType) {
         if (deviceType == DeviceType.band || deviceType == DeviceType.belt) {
@@ -63,40 +64,53 @@ class BandScreenTrackList extends StatelessWidget {
     );
   }
 
-  PagedListView<int, InternalMediaFile> buildList(
+  Widget buildList(
     BuildContext context,
     bool hasRecommendation,
     ScrollController? scrollController,
   ) {
-    return PagedListView<int, InternalMediaFile>(
-      scrollDirection:
-          scrollController == null ? Axis.vertical : Axis.horizontal,
-      pagingController: pagingController,
-      scrollController: scrollController,
+    if (totalCount == 0) {
+      return Center(
+        child: NoItems(
+          title: S.of(context).noTracksFound,
+          hasRecommendation: hasRecommendation,
+          reloadData: () {},
+        ),
+      );
+    }
+
+    final listView = ListView.builder(
+      scrollDirection: scrollController == null
+          ? Axis.vertical
+          : Axis.horizontal,
+      controller: scrollController,
       padding: getScrollContainerPadding(context, top: topPadding),
-      builderDelegate: PagedChildBuilderDelegate<InternalMediaFile>(
-        noItemsFoundIndicatorBuilder: (context) {
-          return SizedBox.expand(
-            child: Center(
-              child: NoItems(
-                title: S.of(context).noTracksFound,
-                hasRecommendation: hasRecommendation,
-                reloadData: pagingController.refresh,
-              ),
-            ),
+      itemCount: totalCount,
+      itemBuilder: (context, index) {
+        final item = getItem(index);
+
+        if (item == null) {
+          return const SizedBox(
+            width: 64,
+            height: 64,
+            child: Center(child: ProgressRing()),
           );
-        },
-        itemBuilder: (context, item, index) {
-          return BandViewTrackItem(
-            index: index,
-            item: item,
-            queries: queries,
-            mode: mode,
-            pagingController: pagingController,
-            position: index,
-          );
-        },
-      ),
+        }
+
+        return BandViewTrackItem(
+          index: index,
+          item: item,
+          queries: queries,
+          mode: mode,
+          position: index,
+        );
+      },
+    );
+
+    return Scrollbar(
+      controller: scrollController,
+      thumbVisibility: true,
+      child: listView,
     );
   }
 }
@@ -108,7 +122,6 @@ class BandViewTrackItem extends StatefulWidget {
     required this.item,
     required this.queries,
     required this.mode,
-    required this.pagingController,
     required this.position,
   });
 
@@ -116,7 +129,6 @@ class BandViewTrackItem extends StatefulWidget {
   final InternalMediaFile item;
   final QueryList queries;
   final int mode;
-  final PagingController<int, InternalMediaFile> pagingController;
   final int position;
 
   @override
@@ -142,10 +154,7 @@ class _BandViewTrackItemState extends State<BandViewTrackItem> {
       child: AspectRatio(
         aspectRatio: 1,
         child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: 2,
-            vertical: 1,
-          ),
+          padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 1),
           child: AxPressure(
             child: ContextMenuWrapper(
               contextAttachKey: _contextAttachKey,
@@ -167,7 +176,7 @@ class _BandViewTrackItemState extends State<BandViewTrackItem> {
                   widget.position,
                   widget.item.id,
                   playlistId,
-                  widget.pagingController.refresh,
+                  () {},
                 );
               },
               child: Tile(
@@ -180,11 +189,7 @@ class _BandViewTrackItemState extends State<BandViewTrackItem> {
                     initialPlaybackId: widget.item.id,
                     operateMode: PlaylistOperateMode.replace,
                     instantlyPlay: true,
-                    fallbackPlayingItems: widget.pagingController.itemList
-                            ?.map((x) => x.id)
-                            .map(PlayingItem.inLibrary)
-                            .toList() ??
-                        [],
+                    fallbackPlayingItems: const [],
                   );
                 },
                 child: CoverArt(
@@ -192,7 +197,7 @@ class _BandViewTrackItemState extends State<BandViewTrackItem> {
                   hint: (
                     widget.item.album,
                     widget.item.artist,
-                    'Total Time ${formatTime(widget.item.duration)}'
+                    'Total Time ${formatTime(widget.item.duration)}',
                   ),
                 ),
               ),

--- a/native/hub/src/messages/media_file.rs
+++ b/native/hub/src/messages/media_file.rs
@@ -70,3 +70,11 @@ pub struct SearchMediaFileSummaryRequest {
 pub struct SearchMediaFileSummaryResponse {
     pub result: Vec<MediaFileSummary>,
 }
+
+#[derive(Serialize, Deserialize, DartSignal)]
+pub struct GetMediaFilesCountRequest {}
+
+#[derive(Deserialize, Serialize, RustSignal)]
+pub struct GetMediaFilesCountResponse {
+    pub count: i32,
+}

--- a/native/requests/src/lib.rs
+++ b/native/requests/src/lib.rs
@@ -147,6 +147,11 @@ pub fn define_request_types(_input: TokenStream) -> TokenStream {
         },
         // Lyric
         RequestResponse {
+            request: "GetMediaFilesCountRequest".to_string(),
+            response: Some("GetMediaFilesCountResponse".to_string()),
+            local_only: false,
+        },
+        RequestResponse {
             request: "GetLyricByTrackIdRequest".to_string(),
             response: Some("GetLyricByTrackIdResponse".to_string()),
             local_only: false,


### PR DESCRIPTION
This pull request added a scroll bar to the track list page, which is convenient in many situation. For example, if one just want to manually randomly select a track to listen.

1. All three type of screens / layouts are supported and tested.
2. The scroll bar has correct total count (or progress) initially. This is done by getting the correct total count when enter the track list page, and set the correct scroll bar status. 
3. Lazy loading still remains. For example, track list page only loads first page at first time, if user scroll to the end, the last page starts to get loaded.