### PR TITLE
fix: save button in Mix Studio does not work properly

### DIFF
--- a/lib/utils/dialogs/mix/mix_studio_dialog.dart
+++ b/lib/utils/dialogs/mix/mix_studio_dialog.dart
@@ -207,6 +207,9 @@ class _MixStudioDialogImplementationState
       isLoading = true;
     });
 
+    final editorData = _controller.getData();
+    final queries = mixEditorDataToQuery(editorData);
+
     Mix? response;
     if (widget.mixId != null) {
       response = await updateMix(
@@ -217,7 +220,7 @@ class _MixStudioDialogImplementationState
         int.parse(
           _controller.modeController.selectedValue ?? '99',
         ),
-        mixEditorDataToQuery(_controller.getData()),
+        queries,
       );
     } else {
       response = await createMix(
@@ -227,7 +230,7 @@ class _MixStudioDialogImplementationState
         int.parse(
           _controller.modeController.selectedValue ?? '99',
         ),
-        mixEditorDataToQuery(_controller.getData()),
+        queries,
       );
     }
 

--- a/native/hub/src/handlers/mix.rs
+++ b/native/hub/src/handlers/mix.rs
@@ -154,17 +154,19 @@ impl Signal for UpdateMixRequest {
         .await
         .with_context(|| "Failed to update mix metadata")?;
 
+        let queries_vec: Vec<(String, String)> = request
+            .queries
+            .clone()
+            .into_iter()
+            .map(|x| (x.operator, x.parameter))
+            .collect();
+
         replace_mix_queries(
             &main_db,
             &node_id,
             request.mix_id,
             &mix.hlc_uuid,
-            request
-                .queries
-                .clone()
-                .into_iter()
-                .map(|x| (x.operator, x.parameter))
-                .collect(),
+            queries_vec,
             None,
         )
         .await


### PR DESCRIPTION
Currently in 2.0.0alpha9, I've noticed a bug that Mix Studio will have a high possibility to fail to save correctly.

### Reproduce the issue

1. Create a blank Mix, then add several tracks into the Mix **via right clicking any of a track, then click add to Mix in the context menu** (not via Mix Studio).
2. Assumes that you added 4 tracks in the last step.
3. Open Mix Studio to edit it, now use the Mix studio to add some tracks, then save.
4. Assumes that you added another 3 tracks in the last step.
5. Now open Mix Studio again, the number of tracks in Mix will not be 7, but remains 4. And, the tracks in the Mix now will become a random mixture of the tracks added in Step 1 or Step 3.

### What this PR fix

Through some investigations, I think Mix Studio save button cannot properly handle query scenarios where the same operator has multiple different parameters 

* Uses operator as the unique key → HashMap<String, mix_queries::Model>
* Can only store one query per operator
* If multiple queries with the same operator but different parameters are added, later ones will overwrite earlier ones

I've attempted to operate a fix, and I've tested that it works on my machine, without breaking other functions.

## Summary by Sourcery

Improve mix query persistence by switching to a compound operator-parameter key in the database operations, updating identifier generation, and ensuring the front-end correctly passes query data to the save endpoint.

Bug Fixes:
- Fix Mix Studio save functionality to correctly persist all track queries and prevent query loss

Enhancements:
- Use a compound key of operator and parameter in replace_mix_queries and update CRUD logic to support multiple queries per operator
- Include parameter in HLC UUID generation for mix queries to ensure unique identification
- Refactor UpdateMixRequest and Mix Studio dialog to construct and pass the query list consistently to the API