### PR TITLE
fix: scroll bar incorrect behaviour in certain circumstances

### DIFF
--- a/lib/utils/lerp_controller.dart
+++ b/lib/utils/lerp_controller.dart
@@ -60,5 +60,11 @@ class LerpController {
     return a + (b - a) * t;
   }
 
+  void syncValue(double value) {
+    _value = value;
+  }
+
+  bool get isAnimating => _ticker?.isTicking ?? false;
+
   double get value => _value;
 }

--- a/lib/widgets/smooth_horizontal_scroll.dart
+++ b/lib/widgets/smooth_horizontal_scroll.dart
@@ -20,6 +20,13 @@ class SmoothScrollController extends ScrollController {
       setter: (value) => jumpTo(value),
       vsync: vsync,
     );
+    addListener(_handleExternalScroll);
+  }
+
+  void _handleExternalScroll() {
+    if (!_lerpController.isAnimating) {
+      _lerpController.syncValue(offset);
+    }
   }
 
   void smoothScrollBy(double delta) {
@@ -36,6 +43,7 @@ class SmoothScrollController extends ScrollController {
 
   @override
   void dispose() {
+    removeListener(_handleExternalScroll);
     _lerpController.dispose();
     super.dispose();
   }


### PR DESCRIPTION
Since I added the scrollbar feature to the track list page, I noticed an issue: after dragging the scrollbar with the left mouse button, using the mouse wheel would cause the scrollbar to jump back to the far left.
This pull request fixes that problem.

## Summary by Sourcery

Fix scrollbar jumping by synchronizing the smooth scroll controller’s internal value with external scroll events and cleaning up listeners

Bug Fixes:
- Prevent scrollbar from snapping back after dragging by syncing the lerp controller value on external scrolls

Enhancements:
- Expose LerpController.isAnimating and add syncValue method for manual value updates

Chores:
- Remove scroll listener on dispose to avoid potential memory leaks