### PR TITLE
fix(linux): disable gtk header bar by default

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -65,24 +65,8 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
-  // Use a header bar when running in GNOME as this is the common style used
-  // by applications and is the setup most users will be using (e.g. Ubuntu
-  // desktop).
-  // If running on X and not using GNOME then just use a traditional title bar
-  // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
-#ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
-  if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
-    }
-  }
-#endif
-  if (use_header_bar) {
+  // Enforce client side decorations iff. GTK_CSD is present and equal to 1
+  if (g_strcmp0(g_getenv("GTK_CSD"), "1") == 0) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
     gtk_header_bar_set_title(header_bar, "rune");

--- a/native/hub/src/handlers/library_manage.rs
+++ b/native/hub/src/handlers/library_manage.rs
@@ -2,7 +2,6 @@ use std::{path::Path, sync::Arc};
 
 use anyhow::{Context, Result};
 use log::{debug, info, warn};
-use sync::hlc::SyncTaskContext;
 use tokio::{sync::Mutex, task};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -389,7 +388,7 @@ impl Signal for DeduplicateAudioLibraryRequest {
                          return Ok(());
                     }
                 };
-                let hlc_context = Arc::new(SyncTaskContext::new(uuid_node_id));
+                let node_id = uuid_node_id.to_string();
 
                 // Stage 1: Compute fingerprints (0% - 33%)
                 let broadcaster_clone = Arc::clone(&broadcaster);
@@ -400,7 +399,7 @@ impl Signal for DeduplicateAudioLibraryRequest {
                     fsio,
                     &main_db,
                     Path::new(&request_path_clone),
-                    hlc_context.clone(),
+                    &node_id,
                     batch_size,
                     move |cur, total| {
                         let progress = cur as f32 / total as f32 * 0.33;
@@ -423,7 +422,7 @@ impl Signal for DeduplicateAudioLibraryRequest {
 
                 compare_all_pairs(
                     &main_db,
-                    hlc_context,
+                    &node_id,
                     batch_size,
                     move |cur, total| {
                         let progress = 0.33 + cur as f32 / total as f32 * 0.33;


### PR DESCRIPTION
GNOME
| Before | After |
|-|-|
|<img width="2560" height="1440" alt="GNOME Before" src="https://github.com/user-attachments/assets/e5016fbe-83f8-4331-a2e3-1399e1542dd8" />|<img width="2560" height="1440" alt="GNOME After" src="https://github.com/user-attachments/assets/3e34210a-a85b-48dd-8c62-2917c46af2fb" />|

Niri
| Before | After |
|-|-|
|<img width="1922" height="2101" alt="Niri Before" src="https://github.com/user-attachments/assets/e89f0afb-8af4-4c94-85b3-79c12599faf1" />|<img width="1922" height="2101" alt="Niri After" src="https://github.com/user-attachments/assets/fb8d5588-467b-4e46-9c69-0bd048e8e564" />|
